### PR TITLE
CHANGE: On App Engine use urlfetch's default deadline if None is passed.

### DIFF
--- a/python2/httplib2/__init__.py
+++ b/python2/httplib2/__init__.py
@@ -1099,7 +1099,7 @@ try:
                         allow_truncated=False, follow_redirects=True,
                         deadline=None):
             if deadline is None:
-                deadline = socket.getdefaulttimeout() or 5
+                deadline = socket.getdefaulttimeout()
             return fetch(url, payload=payload, method=method, headers=headers,
                          allow_truncated=allow_truncated,
                          follow_redirects=follow_redirects, deadline=deadline,


### PR DESCRIPTION
Commit 9e1c4e5e56 checks socket.getdefaulttimeout(), but uses 5 if it is not
set. Instead, pass None to urlfetch, so it will use its own built-in
default. This makes this respect urlfetch.set_default_fetch_deadline(), as
it did before.


We upgraded from an ancient version of httplib2 to the current version, and hit this change in behaviour between the two versions. This fixes it to act like the previous.