### PR TITLE
Send SNI data for SSL connections on Python 2.7.9+

### DIFF
--- a/python2/httplib2/__init__.py
+++ b/python2/httplib2/__init__.py
@@ -80,6 +80,7 @@ try:
         if hasattr(ssl, 'SSLContext'): # Python 2.7.9
             context = ssl.SSLContext(ssl_version)
             context.verify_mode = cert_reqs
+            context.check_hostname = (cert_reqs != ssl.CERT_NONE)
             if cert_file:
                 context.load_cert_chain(cert_file, key_file)
             if ca_certs:

--- a/python2/httplib2/__init__.py
+++ b/python2/httplib2/__init__.py
@@ -68,21 +68,31 @@ except ImportError:
 try:
     import ssl # python 2.6
     ssl_SSLError = ssl.SSLError
-    def _ssl_wrap_socket(sock, key_file, cert_file,
-                         disable_validation, ca_certs, ssl_version):
+    def _ssl_wrap_socket(sock, key_file, cert_file, disable_validation,
+                         ca_certs, ssl_version, hostname):
         if disable_validation:
             cert_reqs = ssl.CERT_NONE
         else:
             cert_reqs = ssl.CERT_REQUIRED
         if ssl_version is None:
             ssl_version = ssl.PROTOCOL_SSLv23
-        return ssl.wrap_socket(sock, keyfile=key_file, certfile=cert_file,
-                               cert_reqs=cert_reqs, ca_certs=ca_certs,
-                               ssl_version=ssl_version)
+
+        if hasattr(ssl, 'SSLContext'): # Python 2.7.9
+            context = ssl.SSLContext(ssl_version)
+            context.verify_mode = cert_reqs
+            if cert_file:
+                context.load_cert_chain(cert_file, key_file)
+            if ca_certs:
+                context.load_verify_locations(ca_certs)
+            return context.wrap_socket(sock, server_hostname=hostname)
+        else:
+            return ssl.wrap_socket(sock, keyfile=key_file, certfile=cert_file,
+                                   cert_reqs=cert_reqs, ca_certs=ca_certs,
+                                   ssl_version=ssl_version)
 except (AttributeError, ImportError):
     ssl_SSLError = None
-    def _ssl_wrap_socket(sock, key_file, cert_file,
-                         disable_validation, ca_certs):
+    def _ssl_wrap_socket(sock, key_file, cert_file, disable_validation,
+                         ca_certs, ssl_version, hostname):
         if not disable_validation:
             raise CertificateValidationUnsupported(
                     "SSL certificate validation is not supported without "
@@ -1039,7 +1049,7 @@ class HTTPSConnectionWithTimeout(httplib.HTTPSConnection):
                 self.sock =_ssl_wrap_socket(
                     sock, self.key_file, self.cert_file,
                     self.disable_ssl_certificate_validation, self.ca_certs,
-                    self.ssl_version)
+                    self.ssl_version, self.host)
                 if self.debuglevel > 0:
                     print "connect: (%s, %s)" % (self.host, self.port)
                     if use_proxy:

--- a/python2/httplib2/test/server.key
+++ b/python2/httplib2/test/server.key
@@ -1,0 +1,146 @@
+Private TLS server key file used for HTTPS-related unit tests
+-------------------------------------------------------------
+
+Public Key Info:
+        Public Key Algorithm: RSA
+        Key Security Level: Medium (2048 bits)
+
+modulus:
+        00:cc:fb:f1:c5:de:29:29:40:3f:c4:9f:af:da:f6:be
+        27:f4:6a:00:ae:5a:f2:99:c3:5f:7a:e6:9b:cf:d9:08
+        34:01:9b:ea:fb:da:b5:d0:b5:b2:4e:60:b4:0d:8d:05
+        57:e4:2e:04:d4:57:1a:58:3c:0b:3a:ed:67:a3:13:31
+        58:0a:c2:eb:fd:d6:27:ee:07:95:30:35:b5:98:91:c7
+        a5:9b:be:a9:7e:ae:fd:73:c3:6b:21:bc:52:f8:ef:71
+        db:d3:b1:cd:51:df:b3:37:b3:fd:7d:ae:7e:02:38:be
+        8e:6f:45:55:e5:6d:8a:02:cb:36:c4:17:7a:ea:24:9a
+        72:8d:1e:75:03:3a:6f:c4:cb:a0:3a:50:56:32:bb:4c
+        e2:ea:74:f0:96:31:74:b2:c1:03:e8:c3:d4:a3:59:fc
+        7a:cc:68:35:c4:97:eb:aa:46:fa:64:c3:f9:55:59:22
+        b5:2b:3c:96:84:c6:d2:7d:b4:9f:b9:9c:af:d1:20:30
+        7c:e8:60:4e:ee:0a:60:a0:9d:4e:8a:d8:34:74:bd:f2
+        40:bc:d7:c2:b3:1a:b2:bb:d7:a5:4a:4c:65:94:43:82
+        16:9a:8f:76:2a:05:b0:9e:3d:a7:fb:e2:c7:78:25:f7
+        df:ca:08:ee:ec:4f:cd:1a:3c:03:41:ec:91:c5:50:70
+        4b:
+
+public exponent:
+        01:00:01:
+
+private exponent:
+        00:ad:01:83:b8:7d:dd:fd:ab:f5:66:2d:64:ce:08:ec
+        cb:6a:15:41:87:e6:c8:d5:10:39:78:d0:43:f7:73:f4
+        e1:77:ee:31:b0:e9:92:04:9a:25:e8:d2:e3:84:80:5e
+        5f:24:fd:d6:23:a5:74:5d:be:27:b8:4f:80:e5:f9:1f
+        ef:6f:fd:be:12:1a:7a:cf:02:65:5f:30:25:99:a4:88
+        7d:74:ea:c1:c1:63:4e:15:33:7d:2b:16:f8:6c:94:23
+        63:e6:d3:2d:38:89:f6:87:f0:08:e5:d7:ad:10:90:f5
+        fb:df:5c:04:b8:43:f0:74:95:31:1e:e5:b6:5f:02:0f
+        bb:55:cb:e1:b5:48:9f:1f:d3:1b:55:a7:bc:39:2b:8e
+        6d:14:64:3b:bf:e8:ca:6b:af:a9:f3:13:9a:c6:df:15
+        ef:6d:17:4e:8e:67:6c:41:20:dc:6b:08:0d:b9:14:cd
+        83:10:62:15:e6:b0:89:5d:37:fb:f6:fd:f0:bf:3b:9c
+        0b:e9:fd:b8:de:e4:64:90:bf:81:d5:59:2c:30:43:07
+        b9:60:8c:d0:ac:4f:95:87:aa:38:62:bd:c7:06:a7:c4
+        2d:08:c1:3c:86:10:c7:8e:1e:df:58:bf:95:ad:39:84
+        a0:2b:13:e2:18:e6:4a:80:f0:bc:04:50:bd:7d:cf:23
+        a1:
+
+prime1:
+        00:f0:8f:ad:2f:c9:64:f3:0d:2c:aa:06:17:05:8f:2f
+        d5:cb:92:22:90:05:66:3c:78:75:9d:7b:4c:6a:af:a9
+        1e:d6:28:4f:13:0e:3a:e7:31:49:3d:87:ef:2c:17:70
+        be:69:b3:42:82:6d:9c:b4:13:0a:e4:bc:8c:0f:1a:bd
+        04:b6:a0:be:ba:12:15:bf:04:db:91:1c:26:91:d6:d7
+        f2:ff:2f:0e:5f:96:a1:7c:4b:90:a8:2f:07:2a:cb:dc
+        40:a0:0b:1d:2a:1d:48:98:bd:4a:6b:9d:5c:69:b0:2b
+        6e:9b:2c:b2:a9:cb:28:fe:fa:7f:93:eb:20:c8:59:d0
+        11:
+
+prime2:
+        00:da:23:c0:3e:82:4c:88:7c:d4:fb:de:24:45:eb:9c
+        ae:2c:80:2d:52:a6:95:05:33:b9:d8:c1:7b:52:01:62
+        11:e6:b6:c6:0d:56:a3:68:39:26:9a:90:08:95:12:a9
+        1c:59:f6:0b:1d:af:6d:c0:c6:9b:2e:7a:62:98:21:36
+        e1:15:4c:e6:6d:a4:08:ac:90:af:57:86:71:78:2e:0e
+        cf:59:0f:35:79:cb:6a:a2:e2:30:2a:a8:f2:84:68:bc
+        8a:f2:48:3b:07:d5:a5:34:f3:d3:ec:25:61:38:f1:0a
+        07:f7:7e:29:61:e4:15:01:80:e3:7b:bd:63:9c:2e:16
+        9b:
+
+coefficient:
+        00:cb:b4:d2:9f:b4:04:db:8c:54:e6:ae:a9:28:a0:c9
+        70:ad:7a:94:72:5e:86:33:91:d9:43:61:2b:4d:55:e8
+        b7:25:d2:cd:db:1e:c4:56:95:68:85:e2:9b:4f:31:24
+        3a:40:06:41:1c:aa:7a:31:13:fa:07:e0:a6:59:c3:d1
+        d2:c5:2c:6a:82:98:bb:a1:59:c0:6f:ad:d7:2e:ed:5a
+        64:5f:e6:ea:4a:ee:45:29:d9:0f:96:b3:39:f7:ab:57
+        97:aa:c9:f7:b6:9c:c0:51:5d:9f:01:2c:ec:58:8d:06
+        6a:19:d0:33:74:11:6a:25:7c:8f:b7:31:d2:97:05:02
+        6f:
+
+exp1:
+        00:87:60:43:95:1d:e0:0a:8b:82:74:18:43:42:64:a7
+        05:c8:ae:ef:76:5f:23:7e:aa:47:7e:1d:52:0e:c3:d6
+        07:bd:7b:27:ac:d0:98:43:5c:d0:1b:a9:70:e6:3e:36
+        bb:61:5e:78:f2:4f:5f:1d:53:8e:10:d5:2e:78:9d:92
+        7b:a1:8e:ea:66:6a:21:04:c3:66:10:ce:67:c2:30:c6
+        8c:40:21:2a:14:8e:ff:47:a4:7a:be:ba:e0:6c:ac:16
+        c1:e3:8e:fd:95:a2:af:25:0d:79:61:00:48:6e:4d:ae
+        d3:6a:ce:07:a9:57:e4:35:41:a1:24:0b:f1:01:ee:d1
+        11:
+
+exp2:
+        00:ca:ca:bd:a7:de:fe:43:4c:b9:bb:c4:d2:37:e6:47
+        ec:6c:16:65:0c:17:2d:26:7e:e5:e1:2a:4d:f8:f8:ac
+        31:34:28:ea:89:ef:e7:4d:b7:03:ba:60:f8:79:8d:b5
+        85:53:e4:b6:84:cc:57:de:05:44:b2:ba:b7:f9:f1:b6
+        d1:1d:3a:36:65:eb:3e:dd:1e:4c:c3:b3:8a:bd:4d:24
+        1b:83:11:ee:86:e1:a2:aa:f6:58:0c:f0:af:34:85:21
+        f2:92:36:b0:1a:22:75:c9:7a:7b:a3:67:44:b0:e8:f4
+        88:5f:7e:fb:fd:b3:4a:0b:f1:c4:89:7e:91:a1:d9:fe
+        cd:
+
+
+Public Key ID: 92:D5:B4:2A:B6:A8:64:67:2C:2A:08:DB:51:B8:97:86:5E:44:CD:6C
+Public key's random art:
++--[ RSA 2048]----+
+|     +    .      |
+|    . E  o .     |
+|   o .  . o      |
+|  . o  o .       |
+|   = .= S        |
+|. +.=o +         |
+|o++== .          |
+|++o=             |
+|o .              |
++-----------------+
+
+
+-----BEGIN RSA PRIVATE KEY-----
+MIIEpgIBAAKCAQEAzPvxxd4pKUA/xJ+v2va+J/RqAK5a8pnDX3rmm8/ZCDQBm+r7
+2rXQtbJOYLQNjQVX5C4E1FcaWDwLOu1noxMxWArC6/3WJ+4HlTA1tZiRx6Wbvql+
+rv1zw2shvFL473Hb07HNUd+zN7P9fa5+Aji+jm9FVeVtigLLNsQXeuokmnKNHnUD
+Om/Ey6A6UFYyu0zi6nTwljF0ssED6MPUo1n8esxoNcSX66pG+mTD+VVZIrUrPJaE
+xtJ9tJ+5nK/RIDB86GBO7gpgoJ1Oitg0dL3yQLzXwrMasrvXpUpMZZRDghaaj3Yq
+BbCePaf74sd4Jfffygju7E/NGjwDQeyRxVBwSwIDAQABAoIBAQCtAYO4fd39q/Vm
+LWTOCOzLahVBh+bI1RA5eNBD93P04XfuMbDpkgSaJejS44SAXl8k/dYjpXRdvie4
+T4Dl+R/vb/2+Ehp6zwJlXzAlmaSIfXTqwcFjThUzfSsW+GyUI2Pm0y04ifaH8Ajl
+160QkPX731wEuEPwdJUxHuW2XwIPu1XL4bVInx/TG1WnvDkrjm0UZDu/6Mprr6nz
+E5rG3xXvbRdOjmdsQSDcawgNuRTNgxBiFeawiV03+/b98L87nAvp/bje5GSQv4HV
+WSwwQwe5YIzQrE+Vh6o4Yr3HBqfELQjBPIYQx44e31i/la05hKArE+IY5kqA8LwE
+UL19zyOhAoGBAPCPrS/JZPMNLKoGFwWPL9XLkiKQBWY8eHWde0xqr6ke1ihPEw46
+5zFJPYfvLBdwvmmzQoJtnLQTCuS8jA8avQS2oL66EhW/BNuRHCaR1tfy/y8OX5ah
+fEuQqC8HKsvcQKALHSodSJi9SmudXGmwK26bLLKpyyj++n+T6yDIWdARAoGBANoj
+wD6CTIh81PveJEXrnK4sgC1SppUFM7nYwXtSAWIR5rbGDVajaDkmmpAIlRKpHFn2
+Cx2vbcDGmy56YpghNuEVTOZtpAiskK9XhnF4Lg7PWQ81ectqouIwKqjyhGi8ivJI
+OwfVpTTz0+wlYTjxCgf3filh5BUBgON7vWOcLhabAoGBAIdgQ5Ud4AqLgnQYQ0Jk
+pwXIru92XyN+qkd+HVIOw9YHvXsnrNCYQ1zQG6lw5j42u2FeePJPXx1TjhDVLnid
+knuhjupmaiEEw2YQzmfCMMaMQCEqFI7/R6R6vrrgbKwWweOO/ZWiryUNeWEASG5N
+rtNqzgepV+Q1QaEkC/EB7tERAoGBAMrKvafe/kNMubvE0jfmR+xsFmUMFy0mfuXh
+Kk34+KwxNCjqie/nTbcDumD4eY21hVPktoTMV94FRLK6t/nxttEdOjZl6z7dHkzD
+s4q9TSQbgxHuhuGiqvZYDPCvNIUh8pI2sBoidcl6e6NnRLDo9Ihffvv9s0oL8cSJ
+fpGh2f7NAoGBAMu00p+0BNuMVOauqSigyXCtepRyXoYzkdlDYStNVei3JdLN2x7E
+VpVoheKbTzEkOkAGQRyqejET+gfgplnD0dLFLGqCmLuhWcBvrdcu7VpkX+bqSu5F
+KdkPlrM596tXl6rJ97acwFFdnwEs7FiNBmoZ0DN0EWolfI+3MdKXBQJv
+-----END RSA PRIVATE KEY-----

--- a/python2/httplib2/test/server.pem
+++ b/python2/httplib2/test/server.pem
@@ -1,0 +1,50 @@
+Public, self-signed TLS server key file used for HTTPS-related unit tests
+-------------------------------------------------------------------------
+
+Public Key Information:
+        Public Key Algorithm: RSA
+        Algorithm Security Level: Medium (2048 bits)
+                Modulus (bits 2048):
+                        00:cc:fb:f1:c5:de:29:29:40:3f:c4:9f:af:da:f6:be
+                        27:f4:6a:00:ae:5a:f2:99:c3:5f:7a:e6:9b:cf:d9:08
+                        34:01:9b:ea:fb:da:b5:d0:b5:b2:4e:60:b4:0d:8d:05
+                        57:e4:2e:04:d4:57:1a:58:3c:0b:3a:ed:67:a3:13:31
+                        58:0a:c2:eb:fd:d6:27:ee:07:95:30:35:b5:98:91:c7
+                        a5:9b:be:a9:7e:ae:fd:73:c3:6b:21:bc:52:f8:ef:71
+                        db:d3:b1:cd:51:df:b3:37:b3:fd:7d:ae:7e:02:38:be
+                        8e:6f:45:55:e5:6d:8a:02:cb:36:c4:17:7a:ea:24:9a
+                        72:8d:1e:75:03:3a:6f:c4:cb:a0:3a:50:56:32:bb:4c
+                        e2:ea:74:f0:96:31:74:b2:c1:03:e8:c3:d4:a3:59:fc
+                        7a:cc:68:35:c4:97:eb:aa:46:fa:64:c3:f9:55:59:22
+                        b5:2b:3c:96:84:c6:d2:7d:b4:9f:b9:9c:af:d1:20:30
+                        7c:e8:60:4e:ee:0a:60:a0:9d:4e:8a:d8:34:74:bd:f2
+                        40:bc:d7:c2:b3:1a:b2:bb:d7:a5:4a:4c:65:94:43:82
+                        16:9a:8f:76:2a:05:b0:9e:3d:a7:fb:e2:c7:78:25:f7
+                        df:ca:08:ee:ec:4f:cd:1a:3c:03:41:ec:91:c5:50:70
+                        4b
+                Exponent (bits 24):
+                        01:00:01
+
+Public Key Usage:
+
+Public Key ID: 92d5b42ab6a864672c2a08db51b897865e44cd6c
+
+
+-----BEGIN CERTIFICATE-----
+MIIC+zCCAeOgAwIBAgIJAISbkoXpX75CMA0GCSqGSIb3DQEBBQUAMBQxEjAQBgNV
+BAMMCWxvY2FsaG9zdDAeFw0xNjA2MTcxNDA1NTlaFw0yNjA2MTUxNDA1NTlaMBQx
+EjAQBgNVBAMMCWxvY2FsaG9zdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoC
+ggEBAMz78cXeKSlAP8Sfr9r2vif0agCuWvKZw1965pvP2Qg0AZvq+9q10LWyTmC0
+DY0FV+QuBNRXGlg8CzrtZ6MTMVgKwuv91ifuB5UwNbWYkcelm76pfq79c8NrIbxS
++O9x29OxzVHfszez/X2ufgI4vo5vRVXlbYoCyzbEF3rqJJpyjR51AzpvxMugOlBW
+MrtM4up08JYxdLLBA+jD1KNZ/HrMaDXEl+uqRvpkw/lVWSK1KzyWhMbSfbSfuZyv
+0SAwfOhgTu4KYKCdTorYNHS98kC818KzGrK716VKTGWUQ4IWmo92KgWwnj2n++LH
+eCX338oI7uxPzRo8A0HskcVQcEsCAwEAAaNQME4wHQYDVR0OBBYEFFdXD8Z8k0et
+ZNyM4e4WypNnGlcCMB8GA1UdIwQYMBaAFFdXD8Z8k0etZNyM4e4WypNnGlcCMAwG
+A1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAC4FsnK1Ph/JpdoqSRTCJiVM
+MPFaaavKEEyYdAKPk/Acmb9vf07sqsT+OZg/0obsZG9LxJb7x0iAnhfM3aS+CmO9
+Ym2lXeFDaJ2bHooB9MsG2C3+n8lJUMwxm7Cqpff/lpCK6Z+6MGPx3GRs6HUEl34k
+BB5pue2vqhtFQ03UdHMpAK0M7n3TloAWbFb1a/JmqzTbsQ0oaMHGoECQEAbaBl+a
+/up6vA3iZHq+ZPYS1KIx+xuT/SapLcyUtjfhmq1bROVZP4+6EHMsBMnhJBYKxxHy
+0qKvqJL9X3NQLMgMKKUKzX+BuG2u5aRRyVIqewT/ORjaUr9Y8lU7WlXPf7Ljm6s=
+-----END CERTIFICATE-----

--- a/python2/httplib2/test/test_ssl_context.py
+++ b/python2/httplib2/test/test_ssl_context.py
@@ -1,0 +1,66 @@
+#!/usr/bin/python2
+import BaseHTTPServer
+import logging
+import os.path
+import unittest
+import sys
+
+import httplib2
+
+from httplib2.test import miniserver
+
+logger = logging.getLogger(__name__)
+
+class KeepAliveHandler(BaseHTTPServer.BaseHTTPRequestHandler):
+    """
+    Request handler that keeps the HTTP connection open, so that the test can
+    inspect the resulting SSL connection object
+    """
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header("Content-Length", "0")
+        self.send_header("Connection", "keep-alive")
+        self.end_headers()
+
+        self.close_connection = 0
+
+    def log_message(self, s, *args):
+        # output via logging so nose can catch it
+        logger.info(s, *args)
+
+class HttpsContextTest(unittest.TestCase):
+    def setUp(self):
+        if sys.version_info < (2, 7, 9):
+            return
+
+        self.httpd, self.port = miniserver.start_server(
+            KeepAliveHandler, True)
+
+    def tearDown(self):
+        self.httpd.shutdown()
+
+    def testHttpsContext(self):
+        if sys.version_info < (2, 7, 9):
+            if hasattr(unittest, "skipTest"):
+                self.skipTest("SSLContext requires Python 2.7.9")# Python 2.7.0
+            else:
+                return
+        import ssl
+
+        client = httplib2.Http(
+            ca_certs=os.path.join(os.path.dirname(__file__), 'server.pem'))
+
+        # Establish connection to local server
+        client.request('https://localhost:%d/' % (self.port))
+
+        # Verify that connection uses a TLS context with the correct hostname
+        conn = client.connections['https:localhost:%d' % self.port]
+
+        self.assertIsInstance(conn.sock, ssl.SSLSocket)
+        self.assertTrue(hasattr(conn.sock, 'context'))
+        self.assertIsInstance(conn.sock.context, ssl.SSLContext)
+        self.assertTrue(conn.sock.context.check_hostname)
+        self.assertEqual(conn.sock.server_hostname, 'localhost')
+        self.assertEqual(conn.sock.context.check_hostname, True)
+        self.assertEqual(conn.sock.context.verify_mode, ssl.CERT_REQUIRED)
+        self.assertEqual(conn.sock.context.protocol, ssl.PROTOCOL_SSLv23)


### PR DESCRIPTION
Make use of the backported `ssl.SSLContext` that is available since Python 2.7.9 to send the hostname as part of the SSL connection to the server.