### PR TITLE
Save FileCache over tmpfile

### DIFF
--- a/python2/httplib2/__init__.py
+++ b/python2/httplib2/__init__.py
@@ -44,6 +44,7 @@ import calendar
 import time
 import random
 import errno
+import tempfile
 try:
     from hashlib import sha1 as _sha, md5 as _md5
 except ImportError:
@@ -726,9 +727,15 @@ class FileCache(object):
 
     def set(self, key, value):
         cacheFullPath = os.path.join(self.cache, self.safe(key))
-        f = file(cacheFullPath, "wb")
-        f.write(value)
-        f.close()
+        tmp = tempfile.NamedTemporaryFile()
+        tmp.write(value)
+        tmp.flush()
+        os.fsync(tmp.fileno())
+        tmp.close()
+        try:
+            os.rename(tmp.name, cacheFullPath)
+        except OSError:
+            pass
 
     def delete(self, key):
         cacheFullPath = os.path.join(self.cache, self.safe(key))

--- a/python2/httplib2/__init__.py
+++ b/python2/httplib2/__init__.py
@@ -727,14 +727,11 @@ class FileCache(object):
 
     def set(self, key, value):
         cacheFullPath = os.path.join(self.cache, self.safe(key))
-        handler, tmp = tempfile.mkstemp()
-        tmp = open(tmp, 'w+b')
-        tmp.write(value)
-        tmp.flush()
-        os.fsync(tmp.fileno())
-        tmp.close()
+        fd, tmpPath = tempfile.mkstemp()
+        os.write(fd, value)
+        os.close(fd)
         try:
-            os.rename(tmp.name, cacheFullPath)
+            os.rename(tmpPath, cacheFullPath)
         except OSError:
             pass
 

--- a/python2/httplib2/__init__.py
+++ b/python2/httplib2/__init__.py
@@ -727,7 +727,8 @@ class FileCache(object):
 
     def set(self, key, value):
         cacheFullPath = os.path.join(self.cache, self.safe(key))
-        tmp = tempfile.NamedTemporaryFile()
+        handler, tmp = tempfile.mkstemp()
+        tmp = open(tmp, 'w+b')
         tmp.write(value)
         tmp.flush()
         os.fsync(tmp.fileno())

--- a/python2/httplib2/__init__.py
+++ b/python2/httplib2/__init__.py
@@ -1319,6 +1319,8 @@ class Http(object):
             try:
                 if hasattr(conn, 'sock') and conn.sock is None:
                     conn.connect()
+                if hasattr(body, 'tell') and body.tell() > 0:
+                    body.seek(0) # rewind for retry send file
                 conn.request(method, request_uri, body, headers)
             except socket.timeout:
                 raise

--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -688,7 +688,8 @@ class FileCache(object):
 
     def set(self, key, value):
         cacheFullPath = os.path.join(self.cache, self.safe(key))
-        tmp = tempfile.NamedTemporaryFile()
+        handler, tmp = tempfile.mkstemp()
+        tmp = open(tmp, 'w+b')
         tmp.write(value)
         tmp.flush()
         os.fsync(tmp.fileno())

--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -1000,6 +1000,8 @@ class Http(object):
             try:
                 if conn.sock is None:
                     conn.connect()
+                if hasattr(body, 'tell') and body.tell() > 0:
+                    body.seek(0) # rewind for retry send file
                 conn.request(method, request_uri, body, headers)
             except socket.timeout:
                 conn.close()

--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -44,6 +44,7 @@ import calendar
 import time
 import random
 import errno
+import tempfile
 from hashlib import sha1 as _sha, md5 as _md5
 import hmac
 from gettext import gettext as _
@@ -687,9 +688,15 @@ class FileCache(object):
 
     def set(self, key, value):
         cacheFullPath = os.path.join(self.cache, self.safe(key))
-        f = open(cacheFullPath, "wb")
-        f.write(value)
-        f.close()
+        tmp = tempfile.NamedTemporaryFile()
+        tmp.write(value)
+        tmp.flush()
+        os.fsync(tmp.fileno())
+        tmp.close()
+        try:
+            os.rename(tmp.name, cacheFullPath)
+        except OSError:
+            pass
 
     def delete(self, key):
         cacheFullPath = os.path.join(self.cache, self.safe(key))

--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -688,14 +688,11 @@ class FileCache(object):
 
     def set(self, key, value):
         cacheFullPath = os.path.join(self.cache, self.safe(key))
-        handler, tmp = tempfile.mkstemp()
-        tmp = open(tmp, 'w+b')
-        tmp.write(value)
-        tmp.flush()
-        os.fsync(tmp.fileno())
-        tmp.close()
+        fd, tmpPath = tempfile.mkstemp()
+        os.write(fd, value)
+        os.close(fd)
         try:
-            os.rename(tmp.name, cacheFullPath)
+            os.rename(tmpPath, cacheFullPath)
         except OSError:
             pass
 


### PR DESCRIPTION
Save FileCache to tmpfile and than rename file to cacheName.
This patch is aimed to make safe usage of cache folder for multiple threads\processes

Also it includes my patch to jcgregorio httplib2 repo https://github.com/jcgregorio/httplib2/pull/321
It is useful fix for upload files