### PR TITLE
Get CA_CERTS path from other sources

### DIFF
--- a/python2/httplib2/__init__.py
+++ b/python2/httplib2/__init__.py
@@ -121,6 +121,11 @@ else:
     def iri2uri(uri):
         return uri
 
+try:
+    from httplib2 import certs
+except ImportError:
+    import certs
+
 def has_timeout(timeout): # python 2.6
     if hasattr(socket, '_GLOBAL_DEFAULT_TIMEOUT'):
         return (timeout is not None and timeout is not socket._GLOBAL_DEFAULT_TIMEOUT)
@@ -210,15 +215,7 @@ class NotRunningAppEngineEnvironment(HttpLib2Error): pass
 # requesting that URI again.
 DEFAULT_MAX_REDIRECTS = 5
 
-try:
-    # Users can optionally provide a module that tells us where the CA_CERTS
-    # are located.
-    import ca_certs_locater
-    CA_CERTS = ca_certs_locater.get()
-except ImportError:
-    # Default CA certificates file bundled with httplib2.
-    CA_CERTS = os.path.join(
-        os.path.dirname(os.path.abspath(__file__ )), "cacerts.txt")
+CA_CERTS = certs.where()
 
 # Which headers are hop-by-hop headers by default
 HOP_BY_HOP = ['connection', 'keep-alive', 'proxy-authenticate', 'proxy-authorization', 'te', 'trailers', 'transfer-encoding', 'upgrade']

--- a/python2/httplib2/certs.py
+++ b/python2/httplib2/certs.py
@@ -1,0 +1,34 @@
+"""
+certs
+
+Returns the path to the ca bundle from ca_certs_locater if available, or
+from certifi, if available, or the environmental variable HTTPLIB2_CA_CERTS, 
+if available, or the default CA certificates file bundled with httplib2.
+
+Code originally from Requests library by Kenneth Reitz.
+
+"""
+__version__ = "1.0.0"
+__license__ = "MIT"
+__history__ = """
+"""
+
+import os
+import os.path
+
+try:
+    # Users can optionally provide a module that tells us where the CA_CERTS
+    # are located.
+    from ca_certs_locater import get as where
+except ImportError:
+    try:
+        from certifi import where
+    except ImportError:
+        def where():
+            certpath = os.getenv('HTTPLIB2_CA_CERTS', os.path.join(
+                os.path.dirname(os.path.abspath(__file__ )), "cacerts.txt"))
+
+            return certpath
+
+if __name__ == '__main__':
+    print(where())

--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -57,6 +57,7 @@ except ImportError:
     socks = None
 
 from .iri2uri import iri2uri
+from . import certs
 
 def has_timeout(timeout):
     if hasattr(socket, '_GLOBAL_DEFAULT_TIMEOUT'):
@@ -124,8 +125,7 @@ DEFAULT_MAX_REDIRECTS = 5
 HOP_BY_HOP = ['connection', 'keep-alive', 'proxy-authenticate', 'proxy-authorization', 'te', 'trailers', 'transfer-encoding', 'upgrade']
 
 # Default CA certificates file bundled with httplib2.
-CA_CERTS = os.path.join(
-        os.path.dirname(os.path.abspath(__file__ )), "cacerts.txt")
+CA_CERTS = certs.where()
 
 def _get_end2end_headers(response):
     hopbyhop = list(HOP_BY_HOP)

--- a/python3/httplib2/certs.py
+++ b/python3/httplib2/certs.py
@@ -1,0 +1,27 @@
+"""
+certs
+
+Returns the path to the ca bundle from certifi, if available, or the 
+environmental variable HTTPLIB2_CA_CERTS, if available, or the 
+default CA certificates file bundled with httplib2.
+
+"""
+__version__ = "1.0.0"
+__license__ = "MIT"
+__history__ = """
+"""
+
+import os
+import os.path
+
+try:
+    from certifi import where
+except ImportError:
+    def where():
+        certpath = os.getenv('HTTPLIB2_CA_CERTS', os.path.join(
+            os.path.dirname(os.path.abspath(__file__ )), "cacerts.txt"))
+
+        return certpath
+
+if __name__ == '__main__':
+    print(where())


### PR DESCRIPTION
Get the CA_CERTS path from certifi if available, or from the environment variable HTTPLIB2_CA_CERTS, if available.  Default to the bundled cacerts file.