### PR TITLE
Bugfix for Content-Encoding: deflate

### DIFF
--- a/python2/httplib2/__init__.py
+++ b/python2/httplib2/__init__.py
@@ -426,7 +426,7 @@ def _decompressContent(response, new_content):
             if encoding == 'gzip':
                 content = gzip.GzipFile(fileobj=StringIO.StringIO(new_content)).read()
             if encoding == 'deflate':
-                content = zlib.decompress(content)
+                content = zlib.decompress(content, -zlib.MAX_WBITS)
             response['content-length'] = str(len(content))
             # Record the historical presence of the encoding in a way the won't interfere.
             response['-content-encoding'] = response['content-encoding']

--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -334,7 +334,7 @@ def _decompressContent(response, new_content):
             if encoding == 'gzip':
                 content = gzip.GzipFile(fileobj=io.BytesIO(new_content)).read()
             if encoding == 'deflate':
-                content = zlib.decompress(content)
+                content = zlib.decompress(content, -zlib.MAX_WBITS)
             response['content-length'] = str(len(content))
             # Record the historical presence of the encoding in a way the won't interfere.
             response['-content-encoding'] = response['content-encoding']


### PR DESCRIPTION
Refer to https://stackoverflow.com/a/22311297

zlib library supports:

  RFC 1950 (zlib compressed format)
  RFC 1951 (deflate compressed format)
  RFC 1952 (gzip compressed format)

choosing windowBits

  to (de-)compress deflate format, use wbits = -zlib.MAX_WBITS
  to (de-)compress zlib format, use wbits = zlib.MAX_WBITS
  to (de-)compress gzip format, use wbits = zlib.MAX_WBITS | 16
  See documentation in http://www.zlib.net/manual.html#Advanced (section inflateInit2)

Signed-off-by: Phus Lu <phuslu@hotmail.com>