### PR TITLE
Reading the actual request may trigger CONNRESET on a cached connection

### DIFF
--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -1023,6 +1023,14 @@ class Http(object):
                 pass
             try:
                 response = conn.getresponse()
+                content = b""
+                if method == "HEAD":
+                    conn.close()
+                else:
+                    content = response.read()
+                response = Response(response)
+                if method != "HEAD":
+                    content = _decompressContent(response, content)
             except (http.client.BadStatusLine, http.client.ResponseNotReady):
                 # If we get a BadStatusLine on the first try then that means
                 # the connection just went stale, so retry regardless of the
@@ -1046,16 +1054,6 @@ class Http(object):
                     continue
                 else:
                     raise
-            else:
-                content = b""
-                if method == "HEAD":
-                    conn.close()
-                else:
-                    content = response.read()
-                response = Response(response)
-                if method != "HEAD":
-                    content = _decompressContent(response, content)
-
             break
         return (response, content)
 


### PR DESCRIPTION
This moves the block that reads the data up into the try: block.

I hit this issue while testing aioamqp with pyrabbit. The sequence of events is:
- send request without auth header
- get an error
- … meanwhile, the server starts thinking about what you just did
  (like doing a DNS lookup for its error log)
- re-send the request with auth header
- … the server gets around to deciding that it wants to close your connection, and does so
- get an ECONNRESET error reading the reply. :-(

This can also happen when you're re-using a cached connection after some time and hit the server's decision that it has waited long enough and will now close the connection.

Thus, please apply.

(This is a copy/rebase of https://github.com/jcgregorio/httplib2/pull/320)