### PR TITLE
> fix UnicodeDecodeError using socks5 proxy.

### DIFF
--- a/python2/httplib2/socks.py
+++ b/python2/httplib2/socks.py
@@ -254,7 +254,7 @@ class socksocket(socket.socket):
             if self.__proxy[3]:
                 # Resolve remotely
                 ipaddr = None
-                req = req + chr(0x03).encode() + chr(len(destaddr)).encode() + destaddr
+                req = req + chr(0x03).encode() + chr(len(destaddr)).encode() + destaddr.encode()
             else:
                 # Resolve locally
                 ipaddr = socket.inet_aton(socket.gethostbyname(destaddr))


### PR DESCRIPTION
In python 2, use socks5 proxy, 

```
  File "/Users/kebeliu/workspace/daocloud/dcv_customer_rate/venv/lib/python2.7/site-packages/httplib2/__init__.py", line 1659, in request
    (response, content) = self._request(conn, authority, uri, request_uri, method, body, headers, redirections, cachekey)
  File "/Users/kebeliu/workspace/daocloud/dcv_customer_rate/venv/lib/python2.7/site-packages/httplib2/__init__.py", line 1399, in _request
    (response, content) = self._conn_request(conn, request_uri, method, body, headers)
  File "/Users/kebeliu/workspace/daocloud/dcv_customer_rate/venv/lib/python2.7/site-packages/httplib2/__init__.py", line 1319, in _conn_request
    conn.connect()
  File "/Users/kebeliu/workspace/daocloud/dcv_customer_rate/venv/lib/python2.7/site-packages/httplib2/__init__.py", line 1065, in connect
    sock.connect((self.host, self.port))
  File "/Users/kebeliu/workspace/daocloud/dcv_customer_rate/venv/lib/python2.7/site-packages/httplib2/socks.py", line 421, in connect
    self.__negotiatesocks5(destpair[0], destpair[1])
  File "/Users/kebeliu/workspace/daocloud/dcv_customer_rate/venv/lib/python2.7/site-packages/httplib2/socks.py", line 263, in __negotiatesocks5
    req = req + struct.pack(">H", destport)
UnicodeDecodeError: 'ascii' codec can't decode byte 0xbb in position 1: ordinal not in range(128)

```

Error code:

```
        try:
            ipaddr = socket.inet_aton(destaddr)
            req = req + chr(0x01).encode() + ipaddr
        except socket.error:
            # Well it's not an IP number,  so it's probably a DNS name.
            if self.__proxy[3]:
                # Resolve remotely
                ipaddr = None
                req = req + chr(0x03).encode() + chr(len(destaddr)).encode() + destaddr.encode()
            else:
                # Resolve locally
                ipaddr = socket.inet_aton(socket.gethostbyname(destaddr))
                req = req + chr(0x01).encode() + ipaddr
        req = req + struct.pack(">H", destport)
```

Because `destaddr` is an unicode, this makes `req` be an unicode with some special characters.
`req = req + struct.pack(">H", destport)` will raise an error.
