### PR TITLE
Add method to compute conn_key

### DIFF
--- a/python2/httplib2/__init__.py
+++ b/python2/httplib2/__init__.py
@@ -1312,6 +1312,10 @@ class Http(object):
         self.credentials.clear()
         self.authorizations = []
 
+    def _conn_key_for(self, scheme, authority):
+        """Compute conn_key for (scheme, authority)"""
+        return scheme + ":" + authority
+
     def _conn_request(self, conn, request_uri, method, body, headers):
         i = 0
         seen_bad_status_line = False
@@ -1513,7 +1517,7 @@ class Http(object):
 
             proxy_info = self._get_proxy_info(scheme, authority)
 
-            conn_key = scheme+":"+authority
+            conn_key = self._conn_key_for(scheme, authority)
             if conn_key in self.connections:
                 conn = self.connections[conn_key]
             else:

--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -985,6 +985,10 @@ class Http(object):
         self.credentials.clear()
         self.authorizations = []
 
+    def _conn_key_for(self, scheme, authority):
+        """Compute conn_key for (scheme, authority)"""
+        return scheme + ":" + authority
+
     def _conn_request(self, conn, request_uri, method, body, headers):
         i = 0
         seen_bad_status_line = False
@@ -1179,7 +1183,7 @@ a string that contains the response entity body.
                 scheme = 'https'
                 authority = domain_port[0]
 
-            conn_key = scheme+":"+authority
+            conn_key = self._conn_key_for(scheme, authority)
             if conn_key in self.connections:
                 conn = self.connections[conn_key]
             else:


### PR DESCRIPTION
This patch adds httplib2.Http._conn_key_for method to compute connection cache key,
which will be useful for customizing connection cache behavoir.
This is mainly to fix the ConcurrentObjectUseError as in #66 when sharing the same
object between eventlets in gevent.
User can override the _conn_key_for method with

    def _conn_key_for(self, scheme, authority):
        return thread_name + ":" + scheme + ":" + authority

to disable sharing same connection between threads/eventlets.