### PR TITLE
FIX: A timeout issue when both IPv4 and IPv6 are enabled.

### DIFF
--- a/python2/httplib2/__init__.py
+++ b/python2/httplib2/__init__.py
@@ -945,8 +945,10 @@ class HTTPConnectionWithTimeout(httplib.HTTPConnection):
                     print "connect: (%s, %s) ************" % (self.host, self.port)
                     if use_proxy:
                         print "proxy: %s ************" % str((proxy_host, proxy_port, proxy_rdns, proxy_user, proxy_pass, proxy_headers))
-
-                self.sock.connect((self.host, self.port) + sa[2:])
+                if use_proxy:
+                    self.sock.connect((self.host, self.port) + sa[2:])
+                else:
+                    self.sock.connect(sa)
             except socket.error, msg:
                 if self.debuglevel > 0:
                     print "connect fail: (%s, %s)" % (self.host, self.port)
@@ -1065,7 +1067,11 @@ class HTTPSConnectionWithTimeout(httplib.HTTPSConnection):
 
                 if has_timeout(self.timeout):
                     sock.settimeout(self.timeout)
-                sock.connect((self.host, self.port))
+
+                if use_proxy:
+                    sock.connect((self.host, self.port) + sockaddr[:2])
+                else:
+                    sock.connect(sockaddr)
                 self.sock =_ssl_wrap_socket(
                     sock, self.key_file, self.cert_file,
                     self.disable_ssl_certificate_validation, self.ca_certs,


### PR DESCRIPTION
When a user has both IPv4 and IPv6 enabled, `socket.getaddrinfo` returns 2 entries. The entry for IPv6 has family = 10, while the IPv4 entry has family = 2. In `HTTPSConnectionWithTimeout`, if a socket is created with family = 10 at line 1063, but the host name is resolved as an IPv4 address in line 1068, `sock.connect` times out.

I changed `HTTPConnectionWithTimeout` as well since the code is similar.

It worth mentioning that this issue does not always happen when both IPv4 and IPv6 are enabled. On some machines, it fails consistently but on others it never times out. It may depend on how `socket.connect` resolves host names.

https://github.com/httplib2/httplib2/issues/56 looks like the same case.

Fixes #56.