### PR TITLE
Classifiers: Python 2 is also supported

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ A comprehensive HTTP client library, ``httplib2`` supports many features left ou
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Software Development :: Libraries',


### PR DESCRIPTION
It would also be good to explicitly report supported minor versions too. For example:
```
Programming Language :: Python :: 2
Programming Language :: Python :: 2.7
Programming Language :: Python :: 3.4
Programming Language :: Python :: 3.5
Programming Language :: Python :: 3.6
```
https://pypi.python.org/pypi?%3Aaction=list_classifiers

What minor versions does httplib2 currently support? I can't find it documented anywhere.