### PR TITLE
Drop support for EOL Python <= 2.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,4 @@
 tests:
-	-cd python2 && python2.4 httplib2test.py
-	-cd python2 && python2.5 httplib2test.py
-	-cd python2 && python2.6 httplib2test.py
-	-cd python2 && python2.6 httplib2test_appengine.py
 	cd python2 && python2.7 httplib2test.py
 	cd python2 && python2.7 httplib2test_appengine.py
 	cd python3 && python3.2 httplib2test.py
@@ -19,8 +15,8 @@ release:
 	if [ $(VERSION) -ne $(INLINE_VERSION_3) ]; then exit 1; fi
 	if [ $(VERSION) -ne $(INLINE_VERSION) ]; then exit 1; fi
 
-	-find . -name "*.pyc" | xargs rm 
-	-find . -name "*.orig" | xargs rm 
+	-find . -name "*.pyc" | xargs rm
+	-find . -name "*.orig" | xargs rm
 	-rm -rf python2/.cache
 	-rm -rf python3/.cache
 	-mkdir dist
@@ -28,10 +24,10 @@ release:
 	-rm dist/httplib2-$(VERSION).tar.gz
 	-rm dist/httplib2-$(VERSION).zip
 	-mkdir dist/httplib2-$(VERSION)
-	cp -r python2 $(DST) 
-	cp -r python3 $(DST) 
+	cp -r python2 $(DST)
+	cp -r python3 $(DST)
 	cp setup.py README.md MANIFEST.in CHANGELOG $(DST)
-	cd dist && tar -czv -f httplib2-$(VERSION).tar.gz httplib2-$(VERSION) 
+	cd dist && tar -czv -f httplib2-$(VERSION).tar.gz httplib2-$(VERSION)
 	cd dist && zip httplib2-$(VERSION).zip -r httplib2-$(VERSION)
 	cd dist/httplib2-$(VERSION) && python setup.py sdist --formats=gztar,zip upload
 	wget "http://support.googlecode.com/svn/trunk/scripts/googlecode_upload.py" -O googlecode_upload.py
@@ -39,4 +35,4 @@ release:
 	python googlecode_upload.py --summary="Version $(shell python setup.py --version)" --project=httplib2 dist/*.zip
 
 docs:
-	pudge -v -f --modules=httplib2 --dest=build/doc 
+	pudge -v -f --modules=httplib2 --dest=build/doc

--- a/index.html
+++ b/index.html
@@ -112,7 +112,7 @@ must not be used when handling this request.
 
 <h3>Requirements</h3>
 
-<p>Requires Python 2.3 or later. Does not require
+<p>Requires Python 2.7 or later. Does not require
 any libraries beyond what is found in the core library.</p>
 
 <h3>Download/Installation</h3>

--- a/python2/httplib2/test/miniserver.py
+++ b/python2/httplib2/test/miniserver.py
@@ -1,8 +1,6 @@
 import logging
 import os
-import select
 import SimpleHTTPServer
-import socket
 import SocketServer
 import threading
 
@@ -20,94 +18,8 @@ class ThisDirHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
         logger.info(s, *args)
 
 
-class ShutdownServer(SocketServer.TCPServer):
-    """Mixin that allows serve_forever to be shut down.
-
-    The methods in this mixin are backported from SocketServer.py in the Python
-    2.6.4 standard library. The mixin is unnecessary in 2.6 and later, when
-    BaseServer supports the shutdown method directly.
-    """
-
-    def __init__(self, use_tls, *args, **kwargs):
-        self.__use_tls = use_tls
-        SocketServer.TCPServer.__init__(self, *args, **kwargs)
-        self.__is_shut_down = threading.Event()
-        self.__serving = False
-
-    def server_bind(self):
-        SocketServer.TCPServer.server_bind(self)
-        if self.__use_tls:
-            import ssl
-            self.socket = ssl.wrap_socket(self.socket,
-                    os.path.join(os.path.dirname(__file__), 'server.key'),
-                    os.path.join(os.path.dirname(__file__), 'server.pem'),
-                    True
-            )
-
-
-    def serve_forever(self, poll_interval=0.1):
-        """Handle one request at a time until shutdown.
-
-        Polls for shutdown every poll_interval seconds. Ignores
-        self.timeout. If you need to do periodic tasks, do them in
-        another thread.
-        """
-        self.__serving = True
-        self.__is_shut_down.clear()
-        while self.__serving:
-            r, w, e = select.select([self.socket], [], [], poll_interval)
-            if r:
-                self._handle_request_noblock()
-        self.__is_shut_down.set()
-
-    def shutdown(self):
-        """Stops the serve_forever loop.
-
-        Blocks until the loop has finished. This must be called while
-        serve_forever() is running in another thread, or it will deadlock.
-        """
-        self.__serving = False
-        self.__is_shut_down.wait()
-
-    def handle_request(self):
-        """Handle one request, possibly blocking.
-
-        Respects self.timeout.
-        """
-        # Support people who used socket.settimeout() to escape
-        # handle_request before self.timeout was available.
-        timeout = self.socket.gettimeout()
-        if timeout is None:
-            timeout = self.timeout
-        elif self.timeout is not None:
-            timeout = min(timeout, self.timeout)
-        fd_sets = select.select([self], [], [], timeout)
-        if not fd_sets[0]:
-            self.handle_timeout()
-            return
-        self._handle_request_noblock()
-
-    def _handle_request_noblock(self):
-        """Handle one request, without blocking.
-
-        I assume that select.select has returned that the socket is
-        readable before this function was called, so there should be
-        no risk of blocking in get_request().
-        """
-        try:
-            request, client_address = self.get_request()
-        except socket.error:
-            return
-        if self.verify_request(request, client_address):
-            try:
-                self.process_request(request, client_address)
-            except:
-                self.handle_error(request, client_address)
-                self.close_request(request)
-
-
 def start_server(handler, use_tls=False):
-    httpd = ShutdownServer(use_tls, ("", 0), handler)
+    httpd = SocketServer.TCPServer(use_tls, ("", 0), handler)
     threading.Thread(target=httpd.serve_forever).start()
     _, port = httpd.socket.getsockname()
     return httpd, port

--- a/python2/httplib2test.py
+++ b/python2/httplib2test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2.7
 """
 httplib2test
 
@@ -100,8 +99,7 @@ class UrlSafenameTest(unittest.TestCase):
         self.assertEqual(233, len(httplib2.safename(uri2)))
         self.assertEqual(233, len(httplib2.safename(uri)))
         # Unicode
-        if sys.version_info >= (2, 7):
-            self.assertEqual( "xn--http,-4y1d.org,fred,a=b,579924c35db315e5a32e3d9963388193", httplib2.safename(u"http://\u2304.org/fred/?a=b"))
+        self.assertEqual( "xn--http,-4y1d.org,fred,a=b,579924c35db315e5a32e3d9963388193", httplib2.safename(u"http://\u2304.org/fred/?a=b"))
 
 class _MyResponse(StringIO.StringIO):
     def __init__(self, body, **kwargs):
@@ -254,12 +252,11 @@ class HttpTest(unittest.TestCase):
         self.assertEqual(response.status, 400)
 
     def testGetIRI(self):
-        if sys.version_info >= (2, 7):
-            uri = urlparse.urljoin(base, u"reflector/reflector.cgi?d=\N{CYRILLIC CAPITAL LETTER DJE}")
-            (response, content) = self.http.request(uri, "GET")
-            d = self.reflector(content)
-            self.assertTrue(d.has_key('QUERY_STRING'))
-            self.assertTrue(d['QUERY_STRING'].find('%D0%82') > 0)
+        uri = urlparse.urljoin(base, u"reflector/reflector.cgi?d=\N{CYRILLIC CAPITAL LETTER DJE}")
+        (response, content) = self.http.request(uri, "GET")
+        d = self.reflector(content)
+        self.assertTrue(d.has_key('QUERY_STRING'))
+        self.assertTrue(d['QUERY_STRING'].find('%D0%82') > 0)
 
     def testGetIsDefaultMethod(self):
         # Test that GET is the default method

--- a/python2/httplib2test.py
+++ b/python2/httplib2test.py
@@ -1,10 +1,10 @@
-#!/usr/bin/env python2.4
+#!/usr/bin/env python2.7
 """
 httplib2test
 
 A set of unit tests for httplib2.py.
 
-Requires Python 2.4 or later
+Requires Python 2.7 or later
 """
 
 __author__ = "Joe Gregorio (joe@bitworking.org)"
@@ -31,11 +31,6 @@ try:
     import ssl
 except ImportError:
     pass
-
-# Python 2.3 support
-if not hasattr(unittest.TestCase, 'assertTrue'):
-    unittest.TestCase.assertTrue = unittest.TestCase.failUnless
-    unittest.TestCase.assertFalse = unittest.TestCase.failIf
 
 # The test resources base uri
 base = 'http://bitworking.org/projects/httplib2/test/'
@@ -105,7 +100,7 @@ class UrlSafenameTest(unittest.TestCase):
         self.assertEqual(233, len(httplib2.safename(uri2)))
         self.assertEqual(233, len(httplib2.safename(uri)))
         # Unicode
-        if sys.version_info >= (2,3):
+        if sys.version_info >= (2, 7):
             self.assertEqual( "xn--http,-4y1d.org,fred,a=b,579924c35db315e5a32e3d9963388193", httplib2.safename(u"http://\u2304.org/fred/?a=b"))
 
 class _MyResponse(StringIO.StringIO):
@@ -180,13 +175,9 @@ class HttpTest(unittest.TestCase):
         if os.path.exists(cacheDirName):
             [os.remove(os.path.join(cacheDirName, file)) for file in os.listdir(cacheDirName)]
 
-        if sys.version_info < (2, 6):
-            disable_cert_validation = True
-        else:
-            disable_cert_validation = False
         self.http = httplib2.Http(
                 cacheDirName,
-                disable_ssl_certificate_validation=disable_cert_validation)
+                disable_ssl_certificate_validation=False)
         self.http.clear_credentials()
 
     def testIPv6NoSSL(self):
@@ -263,7 +254,7 @@ class HttpTest(unittest.TestCase):
         self.assertEqual(response.status, 400)
 
     def testGetIRI(self):
-        if sys.version_info >= (2,3):
+        if sys.version_info >= (2, 7):
             uri = urlparse.urljoin(base, u"reflector/reflector.cgi?d=\N{CYRILLIC CAPITAL LETTER DJE}")
             (response, content) = self.http.request(uri, "GET")
             d = self.reflector(content)
@@ -510,34 +501,6 @@ class HttpTest(unittest.TestCase):
         (response, content) = self.http.request("https://www.google.com/adsense", "GET")
         self.assertEqual(200, response.status)
         self.assertNotEqual(None, response.previous)
-
-    def testSslCertValidationDoubleDots(self):
-        pass
-        # No longer a valid test.
-        #if sys.version_info >= (2, 6):
-        # Test that we get match a double dot cert
-        #try:
-        #  self.http.request("https://www.appspot.com/", "GET")
-        #except httplib2.CertificateHostnameMismatch:
-        #  self.fail('cert with *.*.appspot.com should not raise an exception.')
-
-    def testSslHostnameValidation(self):
-      pass
-        # No longer a valid test.
-        #if sys.version_info >= (2, 6):
-            # The SSL server at google.com:443 returns a certificate for
-            # 'www.google.com', which results in a host name mismatch.
-            # Note that this test only works because the ssl module and httplib2
-            # do not support SNI; for requests specifying a server name of
-            # 'google.com' via SNI, a matching cert would be returned.
-        #    self.assertRaises(httplib2.CertificateHostnameMismatch,
-        #            self.http.request, "https://google.com/", "GET")
-
-    def testSslCertValidationWithoutSslModuleFails(self):
-        if sys.version_info < (2, 6):
-            http = httplib2.Http(disable_ssl_certificate_validation=False)
-            self.assertRaises(httplib2.CertificateValidationUnsupported,
-                    http.request, "https://www.google.com/", "GET")
 
     def testGetViaHttpsKeyCert(self):
         #  At this point I can only test

--- a/python2/ssl_protocol_test.py
+++ b/python2/ssl_protocol_test.py
@@ -10,24 +10,18 @@ import unittest
 class TestSslProtocol(unittest.TestCase):
 
   def testSslCertValidationWithInvalidCaCert(self):
-    if sys.version_info >= (2, 6):
-      http = httplib2.Http(ca_certs='/nosuchfile')
-      if sys.version_info >= (2, 7):
-        with self.assertRaises(IOError):
-          http.request('https://www.google.com/', 'GET')
-      else:
-        self.assertRaises(
-            ssl.SSLError, http.request, 'https://www.google.com/', 'GET')
+    http = httplib2.Http(ca_certs='/nosuchfile')
+    with self.assertRaises(IOError):
+      http.request('https://www.google.com/', 'GET')
 
   def testSslCertValidationWithSelfSignedCaCert(self):
-    if sys.version_info >= (2, 7):
-      other_ca_certs = os.path.join(
-          os.path.dirname(os.path.abspath(httplib2.__file__ )), 'test',
-          'other_cacerts.txt')
-      http = httplib2.Http(ca_certs=other_ca_certs)
-      if sys.platform != 'darwin':
-        with self.assertRaises(httplib2.SSLHandshakeError):
-          http.request('https://www.google.com/', 'GET')
+    other_ca_certs = os.path.join(
+        os.path.dirname(os.path.abspath(httplib2.__file__ )), 'test',
+        'other_cacerts.txt')
+    http = httplib2.Http(ca_certs=other_ca_certs)
+    if sys.platform != 'darwin':
+      with self.assertRaises(httplib2.SSLHandshakeError):
+        http.request('https://www.google.com/', 'GET')
 
   def testSslProtocolTlsV1AndShouldPass(self):
     http = httplib2.Http(ssl_version=ssl.PROTOCOL_TLSv1)
@@ -35,8 +29,7 @@ class TestSslProtocol(unittest.TestCase):
             'https://www.apple.com',
             'https://www.twitter.com']
     for url in urls:
-      if sys.version_info >= (2, 7):
-        self.assertIsNotNone(http.request(uri=url))
+      self.assertIsNotNone(http.request(uri=url))
 
   def testSslProtocolV3AndShouldFailDueToPoodle(self):
     http = httplib2.Http(ssl_version=ssl.PROTOCOL_SSLv3)
@@ -44,13 +37,12 @@ class TestSslProtocol(unittest.TestCase):
             'https://www.apple.com',
             'https://www.twitter.com']
     for url in urls:
-      if sys.version_info >= (2, 7):
-        with self.assertRaises(httplib2.SSLHandshakeError):
-          http.request(url)
-        try:
-          http.request(url)
-        except httplib2.SSLHandshakeError as e:
-          self.assertTrue('sslv3 alert handshake failure' in str(e))
+      with self.assertRaises(httplib2.SSLHandshakeError):
+        http.request(url)
+      try:
+        http.request(url)
+      except httplib2.SSLHandshakeError as e:
+        self.assertTrue('sslv3 alert handshake failure' in str(e))
 
 
 if __name__ == '__main__':

--- a/python3/httplib2test.py
+++ b/python3/httplib2test.py
@@ -95,8 +95,7 @@ class UrlSafenameTest(unittest.TestCase):
         self.assertEqual(233, len(httplib2.safename(uri2)))
         self.assertEqual(233, len(httplib2.safename(uri)))
         # Unicode
-        if sys.version_info >= (2, 7):
-            self.assertEqual( "xn--http,-4y1d.org,fred,a=b,579924c35db315e5a32e3d9963388193", httplib2.safename("http://\u2304.org/fred/?a=b"))
+        self.assertEqual( "xn--http,-4y1d.org,fred,a=b,579924c35db315e5a32e3d9963388193", httplib2.safename("http://\u2304.org/fred/?a=b"))
 
 class _MyResponse(io.BytesIO):
     def __init__(self, body, **kwargs):
@@ -246,12 +245,11 @@ class HttpTest(unittest.TestCase):
         self.assertEqual(response.status, 400)
 
     def testGetIRI(self):
-        if sys.version_info >= (2, 7):
-            uri = urllib.parse.urljoin(base, "reflector/reflector.cgi?d=\N{CYRILLIC CAPITAL LETTER DJE}")
-            (response, content) = self.http.request(uri, "GET")
-            d = self.reflector(content)
-            self.assertTrue('QUERY_STRING' in d)
-            self.assertTrue(d['QUERY_STRING'].find('%D0%82') > 0)
+        uri = urllib.parse.urljoin(base, "reflector/reflector.cgi?d=\N{CYRILLIC CAPITAL LETTER DJE}")
+        (response, content) = self.http.request(uri, "GET")
+        d = self.reflector(content)
+        self.assertTrue('QUERY_STRING' in d)
+        self.assertTrue(d['QUERY_STRING'].find('%D0%82') > 0)
 
     def testGetIsDefaultMethod(self):
         # Test that GET is the default method

--- a/python3/httplib2test.py
+++ b/python3/httplib2test.py
@@ -95,7 +95,7 @@ class UrlSafenameTest(unittest.TestCase):
         self.assertEqual(233, len(httplib2.safename(uri2)))
         self.assertEqual(233, len(httplib2.safename(uri)))
         # Unicode
-        if sys.version_info >= (2,3):
+        if sys.version_info >= (2, 7):
             self.assertEqual( "xn--http,-4y1d.org,fred,a=b,579924c35db315e5a32e3d9963388193", httplib2.safename("http://\u2304.org/fred/?a=b"))
 
 class _MyResponse(io.BytesIO):
@@ -246,7 +246,7 @@ class HttpTest(unittest.TestCase):
         self.assertEqual(response.status, 400)
 
     def testGetIRI(self):
-        if sys.version_info >= (2,3):
+        if sys.version_info >= (2, 7):
             uri = urllib.parse.urljoin(base, "reflector/reflector.cgi?d=\N{CYRILLIC CAPITAL LETTER DJE}")
             (response, content) = self.http.request(uri, "GET")
             d = self.reflector(content)
@@ -1235,7 +1235,7 @@ class HttpPrivateTest(unittest.TestCase):
         self.assertTrue('cache-control' in h)
         self.assertTrue('other' in h)
         self.assertEqual('Stuff', h['other'])
-    
+
     def testConvertByteStr(self):
         with self.assertRaises(TypeError):
             httplib2._convert_byte_str(4)


### PR DESCRIPTION
Resolves https://github.com/httplib2/httplib2/issues/42 which has ~11~ 12 votes for and no votes against.