### PR TITLE
Run flake8 on all new PRs to find syntax errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: python
+cache: pip
+python:
+    - "2.7"
+    - "3.6"
+install:
+    #- pip install -r requirements.txt
+    - pip install flake8  # pytest  # add another testing frameworks later
+before_script:
+    -  if [ ${TRAVIS_PYTHON_VERSION} == "2.7" ] ; then EXCLUDE="./python3" ; fi
+    -  if [ ${TRAVIS_PYTHON_VERSION} == "3.6" ] ; then EXCLUDE="./python2" ; fi
+    # stop the build if there are Python syntax errors or undefined names
+    - flake8 . --count --exclude=${EXCLUDE} --select=E901,E999,F821,F822,F823 --show-source --statistics
+    # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+    - flake8 . --count --exclude=${EXCLUDE} --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+script:
+    - true  # pytest --capture=sys --showlocals  # add other tests here
+notifications:
+    on_success: change
+    on_failure: change  # `always` will be the setting once code changes slow down


### PR DESCRIPTION
Run [flake8](http://flake8.readthedocs.io) on all new code submissions to find syntax errors and undefined names.  Use ${EXCLUDE} to avoid testing __./python2__ when running Travis is running Python 3 and vice versa.  Output corresponds to #83

* Python 2 output: https://travis-ci.org/httplib2/httplib2/jobs/327584762#L491-L498
* Python 3 output: https://travis-ci.org/httplib2/httplib2/jobs/327584763#L483-L487