### PR TITLE
Cleaned-up python 3 proxy support

### DIFF
--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -871,6 +871,8 @@ class HTTPConnectionWithTimeout(http.client.HTTPConnection):
             port = self.port
             proxy_type = None
 
+        socket_err = None
+
         for res in socket.getaddrinfo(host, port, 0, socket.SOCK_STREAM):
             af, socktype, proto, canonname, sa = res
             try:
@@ -891,8 +893,8 @@ class HTTPConnectionWithTimeout(http.client.HTTPConnection):
                                 (proxy_host, proxy_port, proxy_rdns, proxy_user, proxy_pass, proxy_headers))))
 
                 self.sock.connect((self.host, self.port) + sa[2:])
-            except socket.error as msg:
-                self.msg = msg
+            except socket.error as e:
+                socket_err = e
                 if self.debuglevel > 0:
                     print(
                         "connect fail: ({0}, {1})".format(self.host, self.port))
@@ -906,7 +908,7 @@ class HTTPConnectionWithTimeout(http.client.HTTPConnection):
                 continue
             break
         if not self.sock:
-            raise socket.error(self.msg)
+            raise socket_err
 
 
 class HTTPSConnectionWithTimeout(http.client.HTTPSConnection):
@@ -964,6 +966,8 @@ class HTTPSConnectionWithTimeout(http.client.HTTPSConnection):
             proxy_type = None
             proxy_headers = None
 
+        socket_err = None
+
         address_info = socket.getaddrinfo(host, port, 0, socket.SOCK_STREAM)
         for family, socktype, proto, canonname, sockaddr in address_info:
             try:
@@ -995,8 +999,8 @@ class HTTPSConnectionWithTimeout(http.client.HTTPSConnection):
                 raise
             except (socket.timeout, socket.gaierror):
                 raise
-            except socket.error as error_msg:
-                self.error_msg = error_msg
+            except socket.error as e:
+                socket_err = e
                 if self.debuglevel > 0:
                     print("connect fail: ({0}, {1})".format((self.host, self.port)))
                     if use_proxy:
@@ -1007,7 +1011,7 @@ class HTTPSConnectionWithTimeout(http.client.HTTPSConnection):
                 continue
             break
         if not self.sock:
-            raise socket.error(self.error_msg)
+            raise socket_err
 
 
 SCHEME_TO_CONNECTION = {

--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -137,7 +137,7 @@ CA_CERTS = os.path.join(
 DEFAULT_TLS_VERSION = getattr(ssl, 'PROTOCOL_TLS', None) or getattr(ssl, 'PROTOCOL_SSLv23')
 
 
-def _build_ssl_context(disable_ssl_certificate_validation, ca_certs=None, cert_file=None, key_file=None):
+def _build_ssl_context(disable_ssl_certificate_validation, ca_certs, cert_file=None, key_file=None):
     if not hasattr(ssl, 'SSLContext'):
         raise RuntimeError("httplib2 requires Python 3.2+ for ssl.SSLContext")
 
@@ -150,7 +150,7 @@ def _build_ssl_context(disable_ssl_certificate_validation, ca_certs=None, cert_f
     if hasattr(context, 'check_hostname'):
         context.check_hostname = not disable_ssl_certificate_validation
 
-    context.load_verify_locations(ca_certs if ca_certs else CA_CERTS)
+    context.load_verify_locations(ca_certs)
 
     if cert_file:
         context.load_cert_chain(cert_file, key_file)
@@ -936,7 +936,7 @@ class HTTPSConnectionWithTimeout(http.client.HTTPSConnection):
             else:
                 self.proxy_info = proxy_info('https')
 
-        context = _build_ssl_context(self.disable_ssl_certificate_validation, ca_certs, cert_file, key_file)
+        context = _build_ssl_context(self.disable_ssl_certificate_validation, self.ca_certs, cert_file, key_file)
         super(HTTPSConnectionWithTimeout, self).__init__(host, port=port, key_file=key_file, cert_file=cert_file,
                                                          timeout=timeout, context=context)
 

--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -852,13 +852,12 @@ class HTTPConnectionWithTimeout(http.client.HTTPConnection):
     def __init__(self, host, port=None, timeout=None, proxy_info=None):
         http.client.HTTPConnection.__init__(self, host, port=port,
                                             timeout=timeout)
-        if isinstance(proxy_info, ProxyInfo):
-            self.proxy_info = proxy_info
-        else:
-            try:
-                self.proxy_info = proxy_info()
-            except:
-                print('Proxy scheme not supported, define a valid ProxyInfo instance')
+
+        if proxy_info:
+            if isinstance(proxy_info, ProxyInfo):
+                self.proxy_info = proxy_info
+            else:
+                self.proxy_info = proxy_info('http')
 
     def connect(self):
         """Connect to the host and port specified in __init__."""
@@ -931,13 +930,12 @@ class HTTPSConnectionWithTimeout(http.client.HTTPSConnection):
                  ca_certs=None, disable_ssl_certificate_validation=False):
         self.disable_ssl_certificate_validation = disable_ssl_certificate_validation
         self.ssl_version = None
-        if isinstance(proxy_info, ProxyInfo):
-            self.proxy_info = proxy_info
-        else:
-            try:
-                self.proxy_info = proxy_info()
-            except:
-                print('Proxy scheme not supported, define a valid ProxyInfo instance')
+
+        if proxy_info:
+            if isinstance(proxy_info, ProxyInfo):
+                self.proxy_info = proxy_info
+            else:
+                self.proxy_info = proxy_info('https')
 
         context = None
         if ca_certs is None:

--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -102,7 +102,6 @@ class ProxiesUnavailableError(HttpLib2Error): pass
 
 # Open Items:
 # -----------
-# Proxy support
 
 # Are we removing the cached content too soon on PUT (only delete on 200 Maybe?)
 

--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -972,10 +972,10 @@ class HTTPSConnectionWithTimeout(http.client.HTTPSConnection):
                     self.disable_ssl_certificate_validation, self.ca_certs,
                     self.ssl_version, self.host)
                 if self.debuglevel > 0:
-                    print("connect: (%s, %s)" % (self.host, self.port))
+                    print("connect: ({0}, {1})".format(self.host, self.port))
                     if use_proxy:
-                        print("proxy: %s" % str(
-                            (proxy_host, proxy_port, proxy_rdns, proxy_user, proxy_pass, proxy_headers)))
+                        print("proxy: {0}".format(str(
+                            (proxy_host, proxy_port, proxy_rdns, proxy_user, proxy_pass, proxy_headers))))
             except (ssl.SSLError, ssl.CertificateError) as e:
                 if sock:
                     sock.close()
@@ -995,9 +995,9 @@ class HTTPSConnectionWithTimeout(http.client.HTTPSConnection):
             except socket.error as error_msg:
                 self.error_msg = error_msg
                 if self.debuglevel > 0:
-                    print("connect fail: (%s, %s)" % (self.host, self.port))
+                    print("connect fail: ({0}, {1})".format((self.host, self.port)))
                     if use_proxy:
-                        print("proxy: %s" % str((proxy_host, proxy_port, proxy_rdns, proxy_user, proxy_pass, proxy_headers)))
+                        print("proxy: {0}".format(str((proxy_host, proxy_port, proxy_rdns, proxy_user, proxy_pass, proxy_headers))))
                 if self.sock:
                     self.sock.close()
                 self.sock = None

--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -117,8 +117,6 @@ class ServerNotFoundError(HttpLib2Error): pass
 
 class ProxiesUnavailableError(HttpLib2Error): pass
 
-class SSLHandshakeError(HttpLib2Error): pass
-
 
 # Open Items:
 # -----------
@@ -986,14 +984,7 @@ class HTTPSConnectionWithTimeout(http.client.HTTPSConnection):
                 if self.sock:
                     self.sock.close()
                 self.sock = None
-                # Unfortunately the ssl module doesn't seem to provide any way
-                # to get at more detailed error information, in particular
-                # whether the error is due to certificate validation or
-                # something else (such as SSL protocol mismatch).
-                if getattr(e, 'errno', None) == ssl.SSL_ERROR_SSL:
-                    raise SSLHandshakeError(e)
-                else:
-                    raise
+                raise
             except (socket.timeout, socket.gaierror):
                 raise
             except socket.error as error_msg:

--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -51,24 +51,6 @@ import socket
 import ssl
 
 
-def ssl_wrap_socket(sock, key_file, cert_file, disable_validation,
-                     ca_certs, ssl_version, hostname):
-
-    if not hasattr(ssl, 'SSLContext'):
-        raise RuntimeError("httplib2 requires Python 3.2+ for ssl.SSLContext")
-
-    if ssl_version is None:
-        ssl_version = ssl.PROTOCOL_TLS
-
-    context = ssl.SSLContext(ssl_version)
-    context.verify_mode = ssl.CERT_NONE if disable_validation else ssl.CERT_REQUIRED
-    context.check_hostname = not disable_validation
-    if cert_file:
-        context.load_cert_chain(cert_file, key_file)
-    if ca_certs:
-        context.load_verify_locations(ca_certs)
-    return context.wrap_socket(sock, server_hostname=hostname)
-
 try:
     import socks
 except ImportError:
@@ -146,6 +128,25 @@ HOP_BY_HOP = ['connection', 'keep-alive', 'proxy-authenticate', 'proxy-authoriza
 # Default CA certificates file bundled with httplib2.
 CA_CERTS = os.path.join(
         os.path.dirname(os.path.abspath(__file__ )), "cacerts.txt")
+
+
+def ssl_wrap_socket(sock, key_file, cert_file, disable_validation,
+                     ca_certs, ssl_version, hostname):
+
+    if not hasattr(ssl, 'SSLContext'):
+        raise RuntimeError("httplib2 requires Python 3.2+ for ssl.SSLContext")
+
+    if ssl_version is None:
+        ssl_version = ssl.PROTOCOL_TLS
+
+    context = ssl.SSLContext(ssl_version)
+    context.verify_mode = ssl.CERT_NONE if disable_validation else ssl.CERT_REQUIRED
+    context.check_hostname = not disable_validation
+    if cert_file:
+        context.load_cert_chain(cert_file, key_file)
+    if ca_certs:
+        context.load_verify_locations(ca_certs)
+    return context.wrap_socket(sock, server_hostname=hostname)
 
 def _get_end2end_headers(response):
     hopbyhop = list(HOP_BY_HOP)

--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -143,7 +143,10 @@ def _build_ssl_context(disable_ssl_certificate_validation, ca_certs=None, cert_f
 
     context = ssl.SSLContext(DEFAULT_TLS_VERSION)
     context.verify_mode = ssl.CERT_NONE if disable_ssl_certificate_validation else ssl.CERT_REQUIRED
-    context.check_hostname = not disable_ssl_certificate_validation
+
+    # check_hostname increases security but requires python 3.4+
+    if hasattr(context, 'check_hostname'):
+        context.check_hostname = not disable_ssl_certificate_validation
 
     context.load_verify_locations(ca_certs if ca_certs else CA_CERTS)
 

--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -54,7 +54,7 @@ import ssl
 def ssl_wrap_socket(sock, key_file, cert_file, disable_validation,
                      ca_certs, ssl_version, hostname):
 
-    if not ssl.SSLContext:
+    if hasattr(ssl, 'SSLContext'):
         raise RuntimeError("httplib2 requires Python 3.2+ for ssl.SSLContext")
 
     if ssl_version is None:

--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -146,7 +146,7 @@ DEFAULT_MAX_REDIRECTS = 5
 HOP_BY_HOP = ['connection', 'keep-alive', 'proxy-authenticate', 'proxy-authorization', 'te', 'trailers', 'transfer-encoding', 'upgrade']
 
 # Default CA certificates file bundled with httplib2.
-DEFAULT_CA_CERTS = os.path.join(
+CA_CERTS = os.path.join(
         os.path.dirname(os.path.abspath(__file__ )), "cacerts.txt")
 
 def _get_end2end_headers(response):
@@ -929,7 +929,7 @@ class HTTPSConnectionWithTimeout(http.client.HTTPSConnection):
         context.verify_mode = ssl.CERT_NONE if disable_ssl_certificate_validation else ssl.CERT_REQUIRED
         context.check_hostname = not disable_ssl_certificate_validation
 
-        self.ca_certs = ca_certs if ca_certs else DEFAULT_CA_CERTS
+        self.ca_certs = ca_certs if ca_certs else CA_CERTS
         context.load_verify_locations(self.ca_certs)
 
         if cert_file:

--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -54,7 +54,7 @@ import ssl
 def ssl_wrap_socket(sock, key_file, cert_file, disable_validation,
                      ca_certs, ssl_version, hostname):
 
-    if hasattr(ssl, 'SSLContext'):
+    if not hasattr(ssl, 'SSLContext'):
         raise RuntimeError("httplib2 requires Python 3.2+ for ssl.SSLContext")
 
     if ssl_version is None:
@@ -916,6 +916,10 @@ class HTTPSConnectionWithTimeout(http.client.HTTPSConnection):
     def __init__(self, host, port=None, key_file=None, cert_file=None,
                  timeout=None, proxy_info=None,
                  ca_certs=None, disable_ssl_certificate_validation=False):
+
+        if not hasattr(ssl, 'SSLContext'):
+            raise RuntimeError("httplib2 requires Python 3.2+ for ssl.SSLContext")
+
         self.disable_ssl_certificate_validation = disable_ssl_certificate_validation
         self.ssl_version = ssl.PROTOCOL_TLS
 

--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -931,6 +931,7 @@ class HTTPSConnectionWithTimeout(http.client.HTTPSConnection):
                  ca_certs=None, disable_ssl_certificate_validation=False):
 
         self.disable_ssl_certificate_validation = disable_ssl_certificate_validation
+        self.ca_certs = ca_certs if ca_certs else CA_CERTS
 
         if proxy_info:
             if isinstance(proxy_info, ProxyInfo):

--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -129,6 +129,13 @@ HOP_BY_HOP = ['connection', 'keep-alive', 'proxy-authenticate', 'proxy-authoriza
 CA_CERTS = os.path.join(
         os.path.dirname(os.path.abspath(__file__ )), "cacerts.txt")
 
+# PROTOCOL_TLS is python 3.5.3+. PROTOCOL_SSLv23 is deprecated.
+# Both PROTOCOL_TLS and PROTOCOL_SSLv23 are equivalent and means:
+# > Selects the highest protocol version that both the client and server support.
+# > Despite the name, this option can select “TLS” protocols as well as “SSL”.
+# source: https://docs.python.org/3.5/library/ssl.html#ssl.PROTOCOL_TLS
+DEFAULT_TLS_VERSION = getattr(ssl, 'PROTOCOL_TLS', None) or getattr(ssl, 'PROTOCOL_SSLv23')
+
 
 def ssl_wrap_socket(sock, key_file, cert_file, disable_validation,
                      ca_certs, ssl_version, hostname):
@@ -137,7 +144,7 @@ def ssl_wrap_socket(sock, key_file, cert_file, disable_validation,
         raise RuntimeError("httplib2 requires Python 3.2+ for ssl.SSLContext")
 
     if ssl_version is None:
-        ssl_version = ssl.PROTOCOL_TLS
+        ssl_version = DEFAULT_TLS_VERSION
 
     context = ssl.SSLContext(ssl_version)
     context.verify_mode = ssl.CERT_NONE if disable_validation else ssl.CERT_REQUIRED
@@ -920,7 +927,7 @@ class HTTPSConnectionWithTimeout(http.client.HTTPSConnection):
             raise RuntimeError("httplib2 requires Python 3.2+ for ssl.SSLContext")
 
         self.disable_ssl_certificate_validation = disable_ssl_certificate_validation
-        self.ssl_version = ssl.PROTOCOL_TLS
+        self.ssl_version = DEFAULT_TLS_VERSION
 
         if proxy_info:
             if isinstance(proxy_info, ProxyInfo):


### PR DESCRIPTION
This is adapapted from #73

#73 introduced a lot of white-space changes and automated clean-ups which made the patch hard to review.

It also copy-pasted (!) a socks.py module from SocksiPy.

This version does not ship a socks module, users that require a proxy will need to install their own socks library (I used PySocks) in addition to httplib2.

Since the default value for `proxy_info` is `proxy_info_from_environment`, this means that without any other changes, upgrading to this version will cause httplib2 to respect `HTTP_PROXY` / `HTTPS_PROXY` environment variables.

Closes #53 
Closes #25 
Closes #22
