### PR TITLE
Python3 v0.11.0 HTTPConnectionWithTimeout AttributeError proxy_info

### DIFF
--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -886,13 +886,9 @@ class HTTPConnectionWithTimeout(http.client.HTTPConnection):
         http.client.HTTPConnection.__init__(self, host, port=port,
                                             timeout=timeout)
 
-        if proxy_info:
-            if isinstance(proxy_info, ProxyInfo):
-                self.proxy_info = proxy_info
-            else:
-                self.proxy_info = proxy_info('http')
-        else:
-            self.proxy_info = None
+        self.proxy_info = proxy_info
+        if proxy_info and not isinstance(proxy_info, ProxyInfo):
+            self.proxy_info = proxy_info('http')
 
     def connect(self):
         """Connect to the host and port specified in __init__."""
@@ -969,11 +965,9 @@ class HTTPSConnectionWithTimeout(http.client.HTTPSConnection):
         self.disable_ssl_certificate_validation = disable_ssl_certificate_validation
         self.ca_certs = ca_certs if ca_certs else CA_CERTS
 
-        if proxy_info:
-            if isinstance(proxy_info, ProxyInfo):
-                self.proxy_info = proxy_info
-            else:
-                self.proxy_info = proxy_info('https')
+        self.proxy_info = proxy_info
+        if proxy_info and not isinstance(proxy_info, ProxyInfo):
+            self.proxy_info = proxy_info('https')
 
         context = _build_ssl_context(self.disable_ssl_certificate_validation, self.ca_certs, cert_file, key_file)
         super(HTTPSConnectionWithTimeout, self).__init__(host, port=port, key_file=key_file, cert_file=cert_file,

--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -891,6 +891,8 @@ class HTTPConnectionWithTimeout(http.client.HTTPConnection):
                 self.proxy_info = proxy_info
             else:
                 self.proxy_info = proxy_info('http')
+        else:
+            self.proxy_info = None
 
     def connect(self):
         """Connect to the host and port specified in __init__."""

--- a/python3/httplib2test.py
+++ b/python3/httplib2test.py
@@ -1630,5 +1630,11 @@ class TestProxyInfo(unittest.TestCase):
         pi = httplib2.ProxyInfo(httplib2.socks.PROXY_TYPE_HTTP, 'localhost', 1234, proxy_headers = headers)
         self.assertEqual(pi.proxy_headers, headers)
 
+    # regression: ensure that httplib2.HTTPConnectionWithTimeout initializes when proxy_info is not supplied
+    def test_proxy_init(self):
+        connection = httplib2.HTTPConnectionWithTimeout('www.google.com', 80)
+        connection.request('GET', '/')
+        connection.close()
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
When proxy_info=None, HTTPConnectionWithTimeout's constructor will not set proxy_info to anything, which therefore triggers an AttributeError when connect is called.

For example, this test script:
```
import httplib2
connection = httplib2.HTTPConnectionWithTimeout('www.example.com', 80)
connection.request('GET', '/')
connection.close()
```
Results in:
```
(venv) C02VP0WSHTD8:httplib2_test2 jryan$ python3 test.py
  Traceback (most recent call last):
    File "test.py", line 4, in <module>
      connection.request('GET', '/')
    File "/usr/local/Cellar/python/3.6.4_4/Frameworks/Python.framework/Versions/3.6/lib/python3.6/http/client.py", line 1239, in request
      self._send_request(method, url, body, headers, encode_chunked)
    File "/usr/local/Cellar/python/3.6.4_4/Frameworks/Python.framework/Versions/3.6/lib/python3.6/http/client.py", line 1285, in _send_request
      self.endheaders(body, encode_chunked=encode_chunked)
    File "/usr/local/Cellar/python/3.6.4_4/Frameworks/Python.framework/Versions/3.6/lib/python3.6/http/client.py", line 1234, in endheaders
      self._send_output(message_body, encode_chunked=encode_chunked)
    File "/usr/local/Cellar/python/3.6.4_4/Frameworks/Python.framework/Versions/3.6/lib/python3.6/http/client.py", line 1026, in _send_output
      self.send(msg)
    File "/usr/local/Cellar/python/3.6.4_4/Frameworks/Python.framework/Versions/3.6/lib/python3.6/http/client.py", line 964, in send
      self.connect()
    File "/Users/jryan/Documents/httplib2_test2/httplib2/python3/httplib2/__init__.py", line 897, in connect
      if self.proxy_info and socks is None:
  AttributeError: 'HTTPConnectionWithTimeout' object has no attribute 'proxy_info'
```