### PR TITLE
Avoid AttributeError when Python 3 users omit or pass None as proxy_info arg

### DIFF
--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -891,6 +891,8 @@ class HTTPConnectionWithTimeout(http.client.HTTPConnection):
                 self.proxy_info = proxy_info
             else:
                 self.proxy_info = proxy_info('http')
+        else:
+            self.proxy_info = None
 
     def connect(self):
         """Connect to the host and port specified in __init__."""
@@ -972,6 +974,8 @@ class HTTPSConnectionWithTimeout(http.client.HTTPSConnection):
                 self.proxy_info = proxy_info
             else:
                 self.proxy_info = proxy_info('https')
+        else:
+            self.proxy_info = None
 
         context = _build_ssl_context(self.disable_ssl_certificate_validation, self.ca_certs, cert_file, key_file)
         super(HTTPSConnectionWithTimeout, self).__init__(host, port=port, key_file=key_file, cert_file=cert_file,


### PR DESCRIPTION
0.11.0 introduced a bug for Python 3 users: if an HTTPConnectionWithTimeout or HTTPSConnectionWithTimeout is instantiated with either proxy_info omitted or proxy_info=None, the code fails to set `self.proxy_info` attribute, and when `connect()` is subsequently called an AttributeError is raised. I've had to pin my various projects' dependencies to `httplib>=0.9.2,<0.11.0` to avoid the bug. This PR fixes the bug.

Python 2 users of httplib2 are unaffected by the problem.


