### PR TITLE
Python3 v0.11.0 socks.py NameError: name 'basestring' is not defined

### DIFF
--- a/python2/httplib2/__init__.py
+++ b/python2/httplib2/__init__.py
@@ -848,6 +848,11 @@ class ProxyInfo(object):
                 return True
         return False
 
+    def __repr__(self):
+        return (
+            '<ProxyInfo type={p.proxy_type} host:port={p.proxy_host}:{p.proxy_port} rdns={p.proxy_rdns}' +
+            ' user={p.proxy_user} headers={p.proxy_headers}>').format(p=self)
+
 
 def proxy_info_from_environment(method='http'):
     """

--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -805,6 +805,11 @@ class ProxyInfo(object):
         return True
     return False
 
+  def __repr__(self):
+    return (
+        '<ProxyInfo type={p.proxy_type} host:port={p.proxy_host}:{p.proxy_port} rdns={p.proxy_rdns}' +
+        ' user={p.proxy_user} headers={p.proxy_headers}>').format(p=self)
+
 
 def proxy_info_from_environment(method='http'):
     """

--- a/python3/httplib2/socks.py
+++ b/python3/httplib2/socks.py
@@ -409,7 +409,7 @@ class socksocket(socket.socket):
         To select the proxy server use setproxy().
         """
         # Do a minimal input check first
-        if (not type(destpair) in (list,tuple)) or (len(destpair) < 2) or (not isinstance(destpair[0], basestring)) or (type(destpair[1]) != int):
+        if (not type(destpair) in (list,tuple)) or (len(destpair) < 2) or (not isinstance(destpair[0], str)) or (type(destpair[1]) != int):
             raise GeneralProxyError((5, _generalerrors[5]))
         if self.__proxy[0] == PROXY_TYPE_SOCKS5:
             if self.__proxy[2] != None:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -24,17 +24,19 @@ from six.moves import http_client, queue
 
 @contextlib.contextmanager
 def assert_raises(exc_type):
+    def _name(t):
+        return getattr(t, '__name__', None) or str(t)
+
+    if not isinstance(exc_type, tuple):
+        exc_type = (exc_type,)
+    names = ', '.join(map(_name, exc_type))
+
     try:
         yield
     except exc_type:
         pass
     else:
-        name = str(exc_type)
-        try:
-            name = exc_type.__name__
-        except AttributeError:
-            pass
-        assert False, 'Expected exception {0}'.format(name)
+        assert False, 'Expected exception(s) {0}'.format(names)
 
 
 class BufferedReader(object):

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -3,8 +3,10 @@ Each test must be run in separate process.
 Must use pytest --forked or similar technique.
 '''
 import httplib2
+import mock
 import os
-# import tests
+import socket
+import tests
 
 
 def test_from_url():
@@ -78,3 +80,13 @@ def test_headers():
     headers = {'key0': 'val0', 'key1': 'val1'}
     pi = httplib2.ProxyInfo(httplib2.socks.PROXY_TYPE_HTTP, 'localhost', 1234, proxy_headers=headers)
     assert pi.proxy_headers == headers
+
+
+def test_github_100_socks_basestring():
+    # https://github.com/httplib2/httplib2/pull/100
+    # NameError: name 'basestring' is not defined
+    # TODO: replace invalid address with dummy local server
+    http = httplib2.Http(proxy_info=httplib2.ProxyInfo(httplib2.socks.PROXY_TYPE_HTTP, '255.255.255.255', 8001))
+    with tests.assert_raises(httplib2.ServerNotFoundError):
+        with mock.patch('socket.socket.connect', side_effect=socket.gaierror):
+            http.request('http://255.255.255.255/', 'GET')


### PR DESCRIPTION
Dear Httplib2 team,

I'm creating tools for gcp with Google API Python Client Library.

I get errors tring to run [sample code](https://cloud.google.com/compute/docs/tutorials/python-guide#listinginstances), and I detect a httplib2 bug for python3.

```
Traceback (most recent call last):
  File "sample.py", line 10, in <module>
    main()
  File "sample.py", line 5, in main
    compute = googleapiclient.discovery.build('compute', 'v1')
  File "/Users/xxxxxx/PycharmProjects/gcptools/venv/lib/python3.6/site-packages/oauth2client/_helpers.py", line 133, in positional_wrapper
    return wrapped(*args, **kwargs)
  File "/Users/xxxxxx/PycharmProjects/gcptools/venv/lib/python3.6/site-packages/googleapiclient/discovery.py", line 229, in build
    requested_url, discovery_http, cache_discovery, cache)
  File "/Users/xxxxxx/PycharmProjects/gcptools/venv/lib/python3.6/site-packages/googleapiclient/discovery.py", line 276, in _retrieve_discovery_doc
    resp, content = http.request(actual_url)
  File "/Users/xxxxxx/PycharmProjects/gcptools/venv/lib/python3.6/site-packages/httplib2/__init__.py", line 1509, in request
    (response, content) = self._request(conn, authority, uri, request_uri, method, body, headers, redirections, cachekey)
  File "/Users/xxxxxx/PycharmProjects/gcptools/venv/lib/python3.6/site-packages/httplib2/__init__.py", line 1259, in _request
    (response, content) = self._conn_request(conn, request_uri, method, body, headers)
  File "/Users/xxxxxx/PycharmProjects/gcptools/venv/lib/python3.6/site-packages/httplib2/__init__.py", line 1182, in _conn_request
    conn.connect()
  File "/Users/xxxxxx/PycharmProjects/gcptools/venv/lib/python3.6/site-packages/httplib2/__init__.py", line 1006, in connect
    sock.connect((self.host, self.port))
  File "/Users/xxxxxx/PycharmProjects/gcptools/venv/lib/python3.6/site-packages/httplib2/socks.py", line 412, in connect
    if (not type(destpair) in (list,tuple)) or (len(destpair) < 2) or (not isinstance(destpair[0], basestring)) or (type(destpair[1]) != int):
NameError: name 'basestring' is not defined
```

The builtin `basestring` abstract type was removed on Python3, so I'd like replace `basestring` with `str`.

Thanks.