### PR TITLE
cache: stronger safename; Thanks to Lev Maximov

### DIFF
--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -188,36 +188,33 @@ def urlnorm(uri):
 
 
 # Cache filename construction (original borrowed from Venus http://intertwingly.net/code/venus/)
-re_url_scheme    = re.compile(br'^\w+://')
-re_url_scheme_s  = re.compile(r'^\w+://')
-re_slash         = re.compile(br'[?/:|]+')
+re_url_scheme = re.compile(r'^\w+://')
+re_unsafe = re.compile(r'[^\w\-_.()=!]+', re.ASCII)
+
 
 def safename(filename):
     """Return a filename suitable for the cache.
-
     Strips dangerous and common characters to create a filename we
     can use to store the cache in.
     """
+    if isinstance(filename, bytes):
+        filename_bytes = filename
+        filename = filename.decode('utf-8')
+    else:
+        filename_bytes = filename.encode('utf-8')
+    filemd5 = _md5(filename_bytes).hexdigest()
+    filename = re_url_scheme.sub('', filename)
+    filename = re_unsafe.sub('', filename)
 
-    try:
-        if re_url_scheme_s.match(filename):
-            if isinstance(filename,bytes):
-                filename = filename.decode('utf-8')
-                filename = filename.encode('idna')
-            else:
-                filename = filename.encode('idna')
-    except UnicodeError:
-        pass
-    if isinstance(filename,str):
-        filename=filename.encode('utf-8')
-    filemd5 = _md5(filename).hexdigest().encode('utf-8')
-    filename = re_url_scheme.sub(b"", filename)
-    filename = re_slash.sub(b",", filename)
+    # limit length of filename (vital for Windows)
+    # https://github.com/httplib2/httplib2/pull/74
+    # C:\Users\    <username>    \AppData\Local\Temp\  <safe_filename>  ,   <md5>
+    #   9 chars + max 104 chars  +     20 chars      +       x       +  1  +  32  = max 259 chars
+    # Thus max safe filename x = 93 chars. Let it be 90 to make a round sum:
+    filename = filename[:90]
 
-    # limit length of filename
-    if len(filename)>200:
-        filename=filename[:200]
-    return b",".join((filename, filemd5)).decode('utf-8')
+    return ','.join((filename, filemd5))
+
 
 NORMALIZE_SPACE = re.compile(r'(?:\r\n)?[ \t]+')
 def _normalize_headers(headers):

--- a/tests/test_uri.py
+++ b/tests/test_uri.py
@@ -1,4 +1,5 @@
 import httplib2
+import pytest
 
 
 def test_from_std66():
@@ -49,30 +50,41 @@ def test_norm():
         pass
 
 
-def test_safename():
-    cases = (
+@pytest.mark.parametrize(
+    'data', (
+        ('', ',d41d8cd98f00b204e9800998ecf8427e'),
         ('http://example.org/fred/?a=b',
-            'example.org,fred,a=b,58489f63a7a83c3b7794a6a398ee8b1f'),
+            'example.orgfreda=b,58489f63a7a83c3b7794a6a398ee8b1f'),
         ('http://example.org/fred?/a=b',
-            'example.org,fred,a=b,8c5946d56fec453071f43329ff0be46b'),
+            'example.orgfreda=b,8c5946d56fec453071f43329ff0be46b'),
         ('http://www.example.org/fred?/a=b',
-            'www.example.org,fred,a=b,499c44b8d844a011b67ea2c015116968'),
+            'www.example.orgfreda=b,499c44b8d844a011b67ea2c015116968'),
         ('https://www.example.org/fred?/a=b',
-            'www.example.org,fred,a=b,692e843a333484ce0095b070497ab45d'),
+            'www.example.orgfreda=b,692e843a333484ce0095b070497ab45d'),
         (httplib2.urlnorm('http://WWW')[-1],
             httplib2.safename(httplib2.urlnorm('http://www')[-1])),
         (u'http://\u2304.org/fred/?a=b',
-            'xn--http,-4y1d.org,fred,a=b,579924c35db315e5a32e3d9963388193'),
-    )
-    for a, b in cases:
-        assert httplib2.safename(a) == b
+            '.orgfreda=b,ecaf0f97756c0716de76f593bd60a35e'),
+        ('normal-resource-name.js', 'normal-resource-name.js,8ff7c46fd6e61bf4e91a0a1606954a54'),
+        ('foo://dom/path/brath/carapath', 'dompathbrathcarapath,83db942781ed975c7a5b7c24039f8ca3'),
+        ('with/slash', 'withslash,17cc656656bb8ce2411bd41ead56d176'),
+        ('thisistoomuch' * 42, ('thisistoomuch' * 6) + 'thisistoomuc,c4553439dd179422c6acf6a8ac093eb6'),
+        (u'\u043f\u0440', ',9f18c0db74a9734e9d18461e16345083'),
+        (u'\u043f\u0440'.encode('utf-8'), ',9f18c0db74a9734e9d18461e16345083'),
+        (b'column\tvalues/unstr.zip', 'columnvaluesunstr.zip,b9740dcd0553e11b526450ceb8f76683'),
+    ), ids=str)
+def test_safename(data):
+    result = httplib2.safename(data[0])
+    assert result == data[1]
 
+
+def test_safename2():
     assert httplib2.safename('http://www') != httplib2.safename('https://www')
 
     # Test the max length limits
     uri = 'http://' + ('w' * 200) + '.org'
     uri2 = 'http://' + ('w' * 201) + '.org'
     assert httplib2.safename(uri) != httplib2.safename(uri2)
-    # Max length should be 200 + 1 (',') + 32
-    assert len(httplib2.safename(uri2)) == 233
-    assert len(httplib2.safename(uri)) == 233
+    # Max length should be 90 + 1 (',') + 32 = 123
+    assert len(httplib2.safename(uri2)) == 123
+    assert len(httplib2.safename(uri)) == 123


### PR DESCRIPTION
- safename length limit: 93 chars
- returns str (unicode) on both py2/3
- no idna, just strip all non-ASCII and path-unsafe characters
- the only restriction left: if you pass bytes to safename, they must be valid UTF-8

https://github.com/httplib2/httplib2/issues/27
https://github.com/httplib2/httplib2/pull/74