### PR TITLE
Revert http:443->https workaround

### DIFF
--- a/python2/httplib2/__init__.py
+++ b/python2/httplib2/__init__.py
@@ -1941,10 +1941,6 @@ class Http(object):
             uri = iri2uri(uri)
 
             (scheme, authority, request_uri, defrag_uri) = urlnorm(uri)
-            domain_port = authority.split(":")[0:2]
-            if len(domain_port) == 2 and domain_port[1] == "443" and scheme == "http":
-                scheme = "https"
-                authority = domain_port[0]
 
             proxy_info = self._get_proxy_info(scheme, authority)
 

--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -1733,10 +1733,6 @@ a string that contains the response entity body.
             uri = iri2uri(uri)
 
             (scheme, authority, request_uri, defrag_uri) = urlnorm(uri)
-            domain_port = authority.split(":")[0:2]
-            if len(domain_port) == 2 and domain_port[1] == "443" and scheme == "http":
-                scheme = "https"
-                authority = domain_port[0]
 
             conn_key = scheme + ":" + authority
             conn = self.connections.get(conn_key)

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -194,3 +194,15 @@ def test_connection_proxy_info_attribute_error(conn_type):
     with tests.assert_raises(socket.gaierror):
         with mock.patch("socket.socket.connect", side_effect=socket.gaierror):
             conn.request("GET", "/")
+
+
+def test_http_443_forced_https():
+    http = httplib2.Http()
+    http.force_exception_to_status_code = True
+    uri = "http://localhost:443/"
+    # sorry, using internal structure of Http to check chosen scheme
+    with mock.patch("httplib2.Http._request") as m:
+        http.request(uri)
+        assert len(m.call_args) > 0, "expected Http._request() call"
+        conn = m.call_args[0][0]
+        assert isinstance(conn, httplib2.HTTPConnectionWithTimeout)


### PR DESCRIPTION
This workaround is not needed anymore, right?

Origin: https://code.google.com/archive/p/httplib2/issues/17
> Year: 2008
> a bug on the Google servers end
> Location: header ... redirected to http://www.google.com:443 (instead of https)

Issue: https://github.com/httplib2/httplib2/issues/112 year 2018
Workaround in httplib2 does not allow weird but legitimate request.
`Http().request(..., connection_type=httplib2.HTTPConnectionWithTimeout)` fails on excess TLS-related arguments.

Arguably, this discovered problem that connection classes should have compatible constructor signatures, e.g. `Connection(uri, options)`