### PR TITLE
Python3 HTTP-proxy b64encode TypeError: bytes-like object is required

### DIFF
--- a/python3/httplib2/socks.py
+++ b/python3/httplib2/socks.py
@@ -206,8 +206,14 @@ class socksocket(socket.socket):
         return "\r\n".join(hdrs)
 
     def __getauthheader(self):
-        auth = self.__proxy[4] + ":" + self.__proxy[5]
-        return "Proxy-Authorization: Basic " + base64.b64encode(auth)
+        username = self.__proxy[4]
+        password = self.__proxy[5]
+        if isinstance(username, str):
+            username = username.encode()
+        if isinstance(password, str):
+            password = password.encode()
+        auth = username + b":" + password
+        return "Proxy-Authorization: Basic " + base64.b64encode(auth).decode()
 
     def setproxy(
         self,


### PR DESCRIPTION
In `__getauthheader` auth object is a str. base64.b64encode(auth) expects a byte array, not a str, so it throws an error. Then base64.b64encode(auth) returns a bytes object, which can not be joined with `"Proxy-Authorization: Basic"`