### PR TITLE
 release non-universal wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
       script: test_group=pep8 script/test
     - stage: test
       env: _=py3-pep8
-      python: 3.6
+      python: 3.7
       install: pip install -r requirements-test.txt
       script: test_group=pep8 script/test
     - stage: test
@@ -49,13 +49,13 @@ jobs:
       script: test_group=package script/test
     - stage: test
       env: _=py3-package
-      python: 3.6
+      python: 3.7
       install: pip install $pip_install_common
       script: test_group=package script/test
     - stage: release
       if: (branch = master)
       env: _=pypi-upload-test
-      python: 3.6
+      python: 3.7
       install: pip install $pip_install_common
       script: script/release -auto
       deploy:
@@ -73,7 +73,7 @@ jobs:
     - stage: release
       if: (tag IS present)
       env: _=pypi-upload-public
-      python: 3.6
+      python: 3.7
       install: pip install $pip_install_common
       script: script/release -auto
       deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,9 +64,7 @@ jobs:
         user: httplib2.release.test
         password:
           secure: "XN3oxobC+26UPiS+F1MvL4c6XtytejZ13SkLXCHfgVDPSASzKqF81CnR4EhsnbfZLvSgGHgSlfY5Jve5HF2VR9GzpJMc6wzcfkkeBg6PeRHuMppIqmuoq7BTw81SZL9X62/mju/vxXs2cHpVkwNTSE7W1JH1bVXPj86oAR9xXo9waRuXcyPGNuSqmOd1NPOMbFmeuz+HeArk2Fz7wwo6H5BJuXjOrEOHWD1rzeRchH901PBUrftm54Id2TIVMARW8jm1saQY2FtPWaBv2v/DJC1fKWMJpcNQ3mmcvrrTFC1IJ00dk9XJfqx5hnsRaergc0UvzHoOGEQKSMdg0PUAkvNohAoCf+3GddPkvk8MaZ+aQlijoK6wp93A5dfTxBVZqdhmEdheolbYiJPunzS60bWvaEv6/D15/xyMiwGamUmF1Tx7UIvvm/zj6tAOBWbNEgLRyvQ0qx2RE95GLtp+RXK4pT+Kig1+cof5hrWODuEl1SSLMBySaNLWO73IN9esZu0X1JS7svnROLRJCAvRjppJYswwCPziP+B8XQDeMrhIDMHNzdbtxOPpBAXpYUE764FkzaUTMsK83Q+ugE3Dx8xtrAzT4M0fdiFv+3QEhSUtfvWsLH9zS9wXC5Px9kPKU3FO8mdUyf7A0bIasvJLNcApDJigKjBukToOIsZVFok="
-        # TODO: sdist bdist_wheel
-        # but wheels don't roll well with our 2/3 split code base
-        distributions: "sdist"
+        distributions: "sdist bdist_wheel"
         skip_cleanup: true
         on:
           repo: httplib2/httplib2
@@ -81,9 +79,7 @@ jobs:
         user: httplib2.release
         password:
           secure: "jZAyMFnmbhYChjsb3gRYfESWlio6pgmWEWBRxtBQXYZf+tzyKVISyHuyWkJvOVTP+lOpp2MTPZ2s1UgxGwfzZ/VE034Cz5iA/C6wafmgtSW+wK+KEJFPseHBBA7Gh4ReiAPi2a+i1UXdsJpFNhv36E9tbTq2sEinbisE2lSEQ0KHadjkc+6pvCjlyhmes7QyM5GviWYlWRNj2OIkT8SUuUcWQt7ZEl6kN82MoMHCaf1YxE/i4JUP3VLomWK3RLZJP356Y4IDkzlVhFU4MJ4ubNtoQ/ECM0uQ+nsHzO0k1uGWdF6mMTna7U5gLqUi9rfCK3bLMeVSo+TUCpjI7HkWDaBgVXGTe5dUMJCDfRgqeYa0GnriI74XYJu8NGjMLv30uO58t9E7VQGo2NrFRJDzKAIHANejWnpUPY3XgoN1rlrh52seMjaU2+jO40EC8HvIqeRRwPwhkqCSV2y+IZT2bOFp2nbMWhkUMsxIX7OXt+sy8GvK/ilMleEl7r0tnudsT7lGdnMwXlttI3CIAFGE7E+0zwnxNiMzQDzo+ILVR7ezrCK9M9xVYKGa3i8gkpSn0Fblnltgg7HaEI8YC3rMZe4iu1t0D6cZZUAAp2ZUo3NCJcZ35iUFBhlFvjVDbe2upJgU6GFgtDLjyzCJiKbz8qLRgMFYgT0CGr512e1jBo0="
-        # TODO: sdist bdist_wheel
-        # but wheels don't roll well with our 2/3 split code base
-        distributions: "sdist"
+        distributions: "sdist bdist_wheel"
         skip_cleanup: true
         on:
           repo: httplib2/httplib2

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+0.12.3
+
+  No changes to library. Distribute py3 wheels.
+
 0.12.1
 
   Catch socket timeouts and clear dead connection

--- a/python2/httplib2/__init__.py
+++ b/python2/httplib2/__init__.py
@@ -19,7 +19,7 @@ __contributors__ = [
     "Alex Yu",
 ]
 __license__ = "MIT"
-__version__ = '0.12.1'
+__version__ = '0.12.3'
 
 import base64
 import calendar

--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -15,7 +15,7 @@ __contributors__ = [
     "Alex Yu",
 ]
 __license__ = "MIT"
-__version__ = '0.12.1'
+__version__ = '0.12.3'
 
 import base64
 import calendar

--- a/script/release
+++ b/script/release
@@ -83,19 +83,19 @@ interactive() {
 		confirm "Continue still? [yN] " || exit 1
 	fi
 
-    echo "Building package" >&2
-    find . -name '*.pyc' -o -name '*.pyo' -o -name '*.orig' -delete
-    rm -rf python{2,3}/.cache
-    rm -rf build dist
-    # TODO: sdist bdist_wheel
-    # but wheels don't roll well with our 2/3 split code base
-    local venv=./venv-release
-    if [[ ! -d "$venv" ]] ; then
-        virtualenv $venv
-        $venv/bin/pip install -U pip setuptools wheel twine
-    fi
-    $venv/bin/python setup.py clean --all
-    $venv/bin/python setup.py sdist
+	echo "Building package" >&2
+	find . -name '*.pyc' -o -name '*.pyo' -o -name '*.orig' -delete
+	rm -rf python{2,3}/.cache
+	rm -rf build dist
+	# TODO: sdist bdist_wheel
+	# but wheels don't roll well with our 2/3 split code base
+	local venv=./venv-release
+	if [[ ! -d "$venv" ]] ; then
+		virtualenv $venv
+		$venv/bin/pip install -U pip setuptools wheel twine
+	fi
+	$venv/bin/python setup.py clean --all
+	$venv/bin/python setup.py sdist
 
 	if confirm "Upload to PyPI? Use in special situation, normally CI (Travis) will upload to PyPI. [yN] " ; then
 		$venv/bin/twine upload dist/* || exit 1

--- a/script/release
+++ b/script/release
@@ -87,15 +87,13 @@ interactive() {
 	find . -name '*.pyc' -o -name '*.pyo' -o -name '*.orig' -delete
 	rm -rf python{2,3}/.cache
 	rm -rf build dist
-	# TODO: sdist bdist_wheel
-	# but wheels don't roll well with our 2/3 split code base
 	local venv=./venv-release
 	if [[ ! -d "$venv" ]] ; then
 		virtualenv $venv
 		$venv/bin/pip install -U pip setuptools wheel twine
 	fi
 	$venv/bin/python setup.py clean --all
-	$venv/bin/python setup.py sdist
+	$venv/bin/python setup.py sdist bdist_wheel
 
 	if confirm "Upload to PyPI? Use in special situation, normally CI (Travis) will upload to PyPI. [yN] " ; then
 		$venv/bin/twine upload dist/* || exit 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,8 @@
+# [bdist_wheel]
+# universal = 1
+# FIXME universal wheels don't roll well with our 2/3 split code base
+# https://github.com/httplib2/httplib2/pull/29
+
 [coverage:run]
 omit = */test/*
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools.command.test
 import sys
 
 pkgdir = {"": "python%s" % sys.version_info[0]}
-VERSION = '0.12.1'
+VERSION = '0.12.3'
 
 
 # `python setup.py test` uses existing Python environment, no virtualenv, no pip.


### PR DESCRIPTION
- py3 wheel in CI auto release
- whichever default python you have (also likely py3) for manual (interactive) run of script/release


Appended on top of irrelevant travis and cosmetic indent changes, which may not be accepted.