### PR TITLE
Python3: Use no_proxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: tests
+
 tests:
 	-cd python2 && python2.4 httplib2test.py
 	-cd python2 && python2.5 httplib2test.py

--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -1136,7 +1136,7 @@ class HTTPConnectionWithTimeout(http.client.HTTPConnection):
             raise ProxiesUnavailableError(
                 "Proxy support missing but proxy use was requested!"
             )
-        if self.proxy_info and self.proxy_info.isgood():
+        if self.proxy_info and self.proxy_info.isgood() and self.proxy_info.applies_to(self.host):
             use_proxy = True
             proxy_type, proxy_host, proxy_port, proxy_rdns, proxy_user, proxy_pass, proxy_headers = (
                 self.proxy_info.astuple()


### PR DESCRIPTION
The Python2 version of `HTTP.request` calls `self._get_proxy_info`, which calls `proxy_info.applies_to`