### PR TITLE
Fix debug in HTTPSConnectionWithTimeout.connect

### DIFF
--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -1366,7 +1366,7 @@ class HTTPSConnectionWithTimeout(http.client.HTTPSConnection):
             except socket.error as e:
                 socket_err = e
                 if self.debuglevel > 0:
-                    print("connect fail: ({0}, {1})".format((self.host, self.port)))
+                    print("connect fail: ({0}, {1})".format(self.host, self.port))
                     if use_proxy:
                         print(
                             "proxy: {0}".format(


### PR DESCRIPTION
There was one more layer of parentheses than there should have been.

Fixes #161.