### PR TITLE
Relative import iri2uri

### DIFF
--- a/python2/httplib2/__init__.py
+++ b/python2/httplib2/__init__.py
@@ -129,7 +129,7 @@ if ssl is None:
     _ssl_wrap_socket = _ssl_wrap_socket_unsupported
 
 if sys.version_info >= (2, 3):
-    from iri2uri import iri2uri
+    from .iri2uri import iri2uri
 else:
 
     def iri2uri(uri):


### PR DESCRIPTION
When using IronPython 2.7, importing httplib2 can raise an ImportError. It seems like a bug in IronPython but switching iri2uri's import to a relative import solves the issue and will still work in other python implementations. 

I've put together a simplified example of the structure that can cause the import error in IronPython in [code_structure.zip](https://github.com/httplib2/httplib2/files/4487909/code_structure.zip). It seems that under certain circumstances, once a relative import has been executed, the following absolute import does not search the local directory. 

