### PR TITLE
Ship new test suite in source dist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,6 @@
 recursive-include python2 *.py *.txt
 recursive-include python3 *.py *.txt
+graft test
+graft tests
 include python2/httplib2/test/*.txt
 include requirements*.txt


### PR DESCRIPTION
This makes the test suite available to Debian/Ubuntu/...
It enables distributions to validate the quality of the shipped package.

This new test suite should be used, instead of the deprecated `python3/httplib2test.py` (see: https://github.com/httplib2/httplib2/issues/166)