### PR TITLE
proxy: urllib getproxies works with OS specific sources (like Windows registry)

### DIFF
--- a/python2/httplib2/__init__.py
+++ b/python2/httplib2/__init__.py
@@ -1090,8 +1090,7 @@ def proxy_info_from_environment(method="http"):
     if method not in ["http", "https"]:
         return
 
-    env_var = method + "_proxy"
-    url = os.environ.get(env_var, os.environ.get(env_var.upper()))
+    url = urllib.getproxies().get(method)
     if not url:
         return
     return proxy_info_from_url(url, method, None)
@@ -1628,7 +1627,7 @@ class Http(object):
         `proxy_info` may be:
           - a callable that takes the http scheme ('http' or 'https') and
             returns a ProxyInfo instance per request. By default, uses
-            proxy_nfo_from_environment.
+            proxy_info_from_environment.
           - a ProxyInfo instance (static proxy config).
           - None (proxy disabled).
 

--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -40,7 +40,7 @@ import socket
 import ssl
 import sys
 import time
-import urllib.parse
+import urllib.parse, urllib.request
 import zlib
 
 try:
@@ -1071,8 +1071,7 @@ def proxy_info_from_environment(method="http"):
     if method not in ("http", "https"):
         return
 
-    env_var = method + "_proxy"
-    url = os.environ.get(env_var, os.environ.get(env_var.upper()))
+    url = urllib.request.getproxies().get(method)
     if not url:
         return
     return proxy_info_from_url(url, method, noproxy=None)


### PR DESCRIPTION
Natan Rajchenberg approached me via email with this patch. Using [urllib `getproxies`](https://docs.python.org/3/library/urllib.request.html#urllib.request.getproxies) handles OS specific sources other than environment variables.

LGTM, but have to check for compatibility.