### PR TITLE
WSSE token needs to be string not bytes

### DIFF
--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -551,7 +551,7 @@ def _cnonce():
 def _wsse_username_token(cnonce, iso_now, password):
     return base64.b64encode(
         _sha(("%s%s%s" % (cnonce, iso_now, password)).encode("utf-8")).digest()
-    ).strip()
+    ).strip().decode("utf-8")
 
 
 # For credentials we need two things, first


### PR DESCRIPTION
When `_wsse_username_token` returned bytes, the header would look like
```
UsernameToken Username="username", PasswordDigest="b'Ue8bnW/FAKEWubcqChWs='", Nonce="673552abeefb06a6", Created="2020-09-29T14:42:57Z"
```
And the extra `b'` at the beginning of the password digest would cause authentication to fail.