### PR TITLE
Implement cookie session

### DIFF
--- a/python2/httplib2/__init__.py
+++ b/python2/httplib2/__init__.py
@@ -1754,14 +1754,13 @@ class Http(object):
         self.credentials.clear()
         self.authorizations = []
 
-    def _set_cookie_header(
-            self, headers, request_host, request_uri, is_https, cookies):
+    def _set_cookie_header(self, headers, host, uri, is_https, cookies):
         # Add one-time cookies provided by request parameter
-        cookie_list = ['{0}={1}'.format(n, v) for n, v in cookies.items()]
+        cookie_list = ['{0}={1}'.format(n, v) for n, v in cookies.iteritems()] \
+            if cookies else []
 
         # Add the cookies matched in cookie jar
-        cookie_header = self.cookie_jar.get_header(
-            request_host, request_uri, is_https)
+        cookie_header = self.cookie_jar.get_header(host, uri, is_https)
         if cookie_header:
             cookie_list.append(cookie_header)
 
@@ -2069,8 +2068,7 @@ class Http(object):
             if "range" not in headers and "accept-encoding" not in headers:
                 headers["accept-encoding"] = "gzip, deflate"
 
-            self._set_cookie_header(headers, conn.host, request_uri,
-                                    scheme == 'https', cookies or {})
+            self._set_cookie_header(headers, conn.host, request_uri, scheme == 'https', cookies)
 
             info = email.Message.Message()
             cachekey = None

--- a/python2/httplib2/cookie.py
+++ b/python2/httplib2/cookie.py
@@ -252,9 +252,8 @@ class CookieJar(object):
                 del self._cookies[domain]
             except KeyError:
                 pass
-            return
         else:
-            self._cookies = {}
+            self._cookies.clear()
 
         if self.filename:
             self.save(self.filename)

--- a/python2/httplib2/cookie.py
+++ b/python2/httplib2/cookie.py
@@ -155,7 +155,7 @@ class CookieJar(object):
                 )
                 fd.write(cookie_line + "\n")
 
-    def set(self, cookie, value=None, **kwargs):
+    def set(self, cookie, value=None, domain=None, path=None, max_age=None, expires=None, secure=False):
         """Put a new cookie or update the existing cookie to this cookie jar.
 
         cookie:
@@ -165,7 +165,8 @@ class CookieJar(object):
         """
         if not isinstance(cookie, Cookie):
             assert cookie is not None and value is not None, "name and value must be given to create a cookie"
-            cookie = Cookie.create(cookie, value, **kwargs)
+            cookie = Cookie.create(cookie, value, domain, path, max_age, expires, secure)
+
         path_cookies = self._cookies.setdefault(cookie.domain, {}).setdefault(cookie.path, {})
         path_cookies[cookie.name] = cookie
 
@@ -232,48 +233,52 @@ class CookieJar(object):
 
         No error if no matching cookie found.
         """
-        try:
-            if name is not None:
-                assert domain and path, "domain and path must be given to remove a cookie by name"
-                path = Cookie.normalize_path(path)
+        if name is not None:
+            assert domain and path, "domain and path must be given to remove a cookie by name"
+            path = Cookie.normalize_path(path)
+            try:
                 del self._cookies[domain][path][name]
-                return
-
-            if path is not None:
-                assert domain, "domain must be given to remove cookies by path"
-                path = Cookie.normalize_path(path)
+            except KeyError:
+                pass
+        elif path is not None:
+            assert domain, "domain must be given to remove cookies by path"
+            path = Cookie.normalize_path(path)
+            try:
                 del self._cookies[domain][path]
-                return
-
-            if domain is not None:
+            except KeyError:
+                pass
+        elif domain is not None:
+            try:
                 del self._cookies[domain]
-                return
-        except KeyError:
+            except KeyError:
+                pass
             return
-
-        self._cookies = {}
+        else:
+            self._cookies = {}
 
         if self.filename:
-            self.save()
+            self.save(self.filename)
 
-    def _match_path(self, request_uri, cookie_path):
-        return cookie_path[:-1] == request_uri or request_uri.startswith(cookie_path)
+    @staticmethod
+    def _match_path(uri, path):
+        return path[:-1] == uri or uri.startswith(path)
 
-    def _match_domain(self, request_host, cookie_domain):
-        if cookie_domain.startswith("."):
-            return cookie_domain == "." or request_host.endswith(cookie_domain)
-        return request_host == cookie_domain
+    @staticmethod
+    def _match_domain(host, domain):
+        if domain.startswith("."):
+            return domain == "." or host.endswith(domain)
+        return host == domain
 
-    def get_header(self, request_host, request_uri, is_https):
+    def get_header(self, host, uri, is_https):
         """Get the Cookie header to be applied to the request."""
-        cookie_header = []
+        parts = []
 
         for domain, domain_cookies in self._cookies.iteritems():
-            if not self._match_domain(request_host, domain):
+            if not self._match_domain(host, domain):
                 continue
 
             for path, cookies in domain_cookies.iteritems():
-                if not self._match_path(request_uri, path):
+                if not self._match_path(uri, path):
                     continue
 
                 for cookie in cookies.itervalues():
@@ -283,9 +288,9 @@ class CookieJar(object):
                     if cookie.secure and not is_https:
                         continue
 
-                    cookie_header.append("{0}={1}".format(cookie.name, cookie.value))
+                    parts.append("{0}={1}".format(cookie.name, cookie.value))
 
-        return "; ".join(cookie_header)
+        return "; ".join(parts)
 
     @staticmethod
     def parse_iter(header):
@@ -343,7 +348,7 @@ class CookieJar(object):
 
             yield cookie
 
-    def extract_header(self, request_host, request_uri, header):
+    def extract_header(self, host, uri, header):
         """Extract cookies from HTTP-style header(Set-Cookie) and save them
         to cookie jar.
 
@@ -351,8 +356,8 @@ class CookieJar(object):
         disable the cookie.
         """
         for cookie in self.parse_iter(header):
-            domain = cookie.get("domain", request_host)
-            path = cookie.get("path", os.path.dirname(request_uri))
+            domain = cookie.get("domain", host)
+            path = cookie.get("path", os.path.dirname(uri))
 
             cookie = Cookie.create(
                 cookie["name"],
@@ -368,14 +373,6 @@ class CookieJar(object):
 
 
 class NullCookieJar(object):
-    def __init__(self):
-        pass
-
-    def load(self, filename):
-        pass
-
-    def save(self, filename):
-        pass
 
     def set(self, cookie, value=None, **kwargs):
         pass
@@ -390,7 +387,7 @@ class NullCookieJar(object):
     def clear(self, domain=None, path=None, name=None):
         pass
 
-    def get_header(self, request_host, request_uri, is_https):
+    def get_header(self, host, uri, is_https):
         return ""
 
     @staticmethod
@@ -398,5 +395,5 @@ class NullCookieJar(object):
         return
         yield
 
-    def extract_header(self, request_host, request_uri, header):
+    def extract_header(self, host, uri, header):
         pass

--- a/python2/httplib2/cookie.py
+++ b/python2/httplib2/cookie.py
@@ -1,0 +1,402 @@
+import os
+import re
+import time
+import email
+import calendar
+from collections import namedtuple
+
+
+RE_SPLIT_COOKIE = re.compile(r"(?:,)\s*(?=[^;, ]*?=[^;, ]*)")
+
+
+CookieBase = namedtuple("Cookie", ["name", "value", "domain", "path", "expires", "secure"])
+
+
+class Cookie(CookieBase):
+    """Represent a Cookie with all attributes."""
+
+    def is_expired(self):
+        return self.expires and (time.time() >= self.expires)
+
+    @staticmethod
+    def normalize_path(path):
+        # A normal cookie path always starts with / and ends with /
+        path = path or "/"
+        if not path.startswith("/"):
+            path = "/" + path
+
+        if not path.endswith("/"):
+            path += "/"
+        return path
+
+    @staticmethod
+    def create(name, value, domain=None, path=None, max_age=None, expires=None, secure=False):
+        """Create a cookie by the given attributes.
+
+        domain:
+            Host to which the cookie will be sent.
+
+            Dot(.) is a special domain in httplib2, that indicates the cookie
+            can be used over all domains. It's also the default value if the
+            domain is not specified.
+
+        path:
+            Path to which the cookie will be sent. The default path is "/" if
+            not specified.
+
+        max_age:
+            Number of seconds until the cookie expires. A zero or negative
+            number will expire the cookie immediately.
+
+            max_age has higher priority than 'expires' date.
+
+        expires:
+            The maximum lifetime of the cookie as an HTTP-date timestamp.
+            Format:
+                <day-name>, <day> <month> <year> <hour>:<minute>:<second> GMT
+            Example: Wed, 21 Oct 2015 07:28:00 GMT
+
+        secure:
+            A secure cookie is only sent to the server when a request is made
+            with the https: scheme. False by default.
+        """
+        if max_age is not None:
+            expires = time.time() + int(max_age)
+        elif expires is not None:
+            expires = calendar.timegm(email.utils.parsedate_tz(expires))
+        else:
+            expires = None
+
+        domain = domain or "."
+        path = Cookie.normalize_path(path)
+
+        return Cookie(name, value, domain, path, expires, secure)
+
+
+class CookieJar(object):
+    """Store and manipulate HTTP Cookies."""
+
+    def __init__(self, init_cookies=None, filename=None):
+        """
+        init_cookies:
+            A dict of cookies {<name>: <value>} to initialize the cookie jar.
+            These cookies are suitable for use over all domains and paths and
+            never expire.
+
+        filename:
+            Cookie file to be loaded and saved. The file will be kept updating
+            when any cookies are added or deleted.
+        """
+
+        # Cookies are stored in hierarchy: domain > path > name > cookie
+        self._cookies = {}
+
+        self.filename = filename
+        if filename and os.path.isfile(filename):
+            self.load(filename)
+
+        for name, value in (init_cookies or {}).iteritems():
+            cookie = Cookie.create(name, value)
+            self.set(cookie)
+
+    def load(self, filename):
+        """Load cookies from file.
+
+        Cookie file format spec:
+            https://curl.haxx.se/docs/http-cookies.html
+        """
+        with open(filename, "rt") as fd:
+            for line in fd:
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue  # blank line
+
+                domain, _, path, secure, expires, name, value = line.split("\t")
+
+                expires = int(expires) if expires else None
+                secure = secure == "TRUE"
+
+                cookie = Cookie(name, value, domain, path, expires, secure)
+
+                cookielist = self._cookies.setdefault(domain, {}).setdefault(path, {})
+                cookielist[name] = cookie
+
+    def save(self, filename):
+        """Save cookies to file.
+
+        Cookie file format spec:
+            https://curl.haxx.se/docs/http-cookies.html
+
+        Note that global cookies (domain attribute is dot) will not be saved.
+        """
+        file_header = """\
+# Netscape HTTP Cookie File
+# https://curl.haxx.se/docs/http-cookies.html
+# This is a generated file! Do not edit.
+
+"""
+        with open(filename, "wt") as fd:
+            fd.write(file_header)
+
+            for cookie in self.iter():
+                if cookie.is_expired() or cookie.domain == ".":
+                    continue
+
+                secure = "TRUE" if cookie.secure else "FALSE"
+                with_subdomain = "TRUE" if cookie.domain.startswith(".") else "FALSE"
+
+                if cookie.expires is not None:
+                    expires = str(int(cookie.expires))
+                else:
+                    expires = ""
+
+                cookie_line = "\t".join(
+                    [cookie.domain, with_subdomain, cookie.path, secure, expires, cookie.name, cookie.value]
+                )
+                fd.write(cookie_line + "\n")
+
+    def set(self, cookie, value=None, **kwargs):
+        """Put a new cookie or update the existing cookie to this cookie jar.
+
+        cookie:
+            Either a cookie name or cookie object.
+            In case it's a cookie name, the value must be provided. And other
+            optional parameters are the same as Cookie.create().
+        """
+        if not isinstance(cookie, Cookie):
+            assert cookie is not None and value is not None, "name and value must be given to create a cookie"
+            cookie = Cookie.create(cookie, value, **kwargs)
+        path_cookies = self._cookies.setdefault(cookie.domain, {}).setdefault(cookie.path, {})
+        path_cookies[cookie.name] = cookie
+
+        if self.filename and cookie.domain != ".":
+            self.save(self.filename)
+
+    def get(self, domain=None, path=None, name=None):
+        """Get cookies filtered by domain, path or name
+
+        If one parameter is specified, the preceding parameter(s) must also
+        be specified.
+
+        If name is specified, only returns the cookie with that name.
+        Otherwise, return a cookie list.
+
+        Return KeyError if no matching cookie found.
+        """
+        if name is not None:
+            assert domain and path, "domain and path must be given to get a cookie by name"
+            path = Cookie.normalize_path(path)
+            return self._cookies[domain][path][name]
+
+        if path is not None:
+            assert domain, "domain must be given to get cookies by path"
+            path = Cookie.normalize_path(path)
+            path_cookies = self._cookies[domain][path]
+            return list(path_cookies.values())
+
+        if domain is not None:
+            return [ck for pc in self._cookies[domain].itervalues() for ck in pc.itervalues()]
+
+        return [ck for dc in self._cookies.itervalues() for pc in dc.itervalues() for ck in pc.itervalues()]
+
+    def iter(self, domain=None, path=None):
+        """Return an iterator of cookies filtered by domain, path.
+
+        If domain and path are not specified, all cookies are returned.
+
+        Raise KeyError if no matching cookie found.
+        """
+        if path is not None:
+            assert domain, "domain must be given to get cookies by path"
+            path = Cookie.normalize_path(path)
+            for ck in self._cookies[domain][path].itervalues():
+                yield ck
+            return
+
+        if domain is not None:
+            for pc in self._cookies[domain].itervalues():
+                for ck in pc.itervalues():
+                    yield ck
+            return
+
+        for dc in self._cookies.itervalues():
+            for pc in dc.itervalues():
+                for ck in pc.itervalues():
+                    yield ck
+
+    def clear(self, domain=None, path=None, name=None):
+        """Delete cookies by domain, path, or name.
+
+        If one parameter is specified, the preceding parameter(s) must also
+        be specified.
+
+        No error if no matching cookie found.
+        """
+        try:
+            if name is not None:
+                assert domain and path, "domain and path must be given to remove a cookie by name"
+                path = Cookie.normalize_path(path)
+                del self._cookies[domain][path][name]
+                return
+
+            if path is not None:
+                assert domain, "domain must be given to remove cookies by path"
+                path = Cookie.normalize_path(path)
+                del self._cookies[domain][path]
+                return
+
+            if domain is not None:
+                del self._cookies[domain]
+                return
+        except KeyError:
+            return
+
+        self._cookies = {}
+
+        if self.filename:
+            self.save()
+
+    def _match_path(self, request_uri, cookie_path):
+        return cookie_path[:-1] == request_uri or request_uri.startswith(cookie_path)
+
+    def _match_domain(self, request_host, cookie_domain):
+        if cookie_domain.startswith("."):
+            return cookie_domain == "." or request_host.endswith(cookie_domain)
+        return request_host == cookie_domain
+
+    def get_header(self, request_host, request_uri, is_https):
+        """Get the Cookie header to be applied to the request."""
+        cookie_header = []
+
+        for domain, domain_cookies in self._cookies.iteritems():
+            if not self._match_domain(request_host, domain):
+                continue
+
+            for path, cookies in domain_cookies.iteritems():
+                if not self._match_path(request_uri, path):
+                    continue
+
+                for cookie in cookies.itervalues():
+                    if cookie.is_expired():
+                        continue
+
+                    if cookie.secure and not is_https:
+                        continue
+
+                    cookie_header.append("{0}={1}".format(cookie.name, cookie.value))
+
+        return "; ".join(cookie_header)
+
+    @staticmethod
+    def parse_iter(header):
+        """An iterator to parse cookies in HTTP-style header(Set-Cookie).
+
+        cookie header example:
+            sid=vBj3zbrmgynsZ8ggVpmSIOc9bXAueT3z; HttpOnly;
+
+        It may contain multiple cookies separated by comma(RFC 2109).
+
+        Example:
+            BD_NOT_HTTPS=1; path=/; Max-Age=300, BIDUPSID=D2504FE922735DE;
+            expires=Thu, 31-Dec-37 23:55:55 GMT; max-age=2147483647; path=/;
+            domain=.example.com, PSTM=1595329370
+
+        The 'expires' also contains comma. Be careful!
+        """
+        if not header:
+            return
+
+        for cookie_str in RE_SPLIT_COOKIE.split(header):
+            attribute_list = cookie_str.split(";")
+            name, value = attribute_list[0].split("=")
+            cookie = {"name": name, "value": value}
+
+            for attr_str in attribute_list[1:]:
+                av_pair = attr_str.split("=", 1)
+                if len(av_pair) == 1:
+                    attr, val = av_pair[0], None
+                else:
+                    attr, val = av_pair
+
+                attr = attr.strip()
+                attr_l = attr.lower()
+
+                if attr_l == "max-age":
+                    cookie["max_age"] = val
+                elif attr_l == "expires":
+                    cookie["expires"] = val
+                elif attr_l == "domain":
+                    domain = val.lower()
+                    if not domain.startswith("."):
+                        domain = "." + domain
+                    cookie["domain"] = domain
+                elif attr_l == "path":
+                    cookie["path"] = val
+                elif attr_l == "secure":
+                    cookie["secure"] = True
+                elif val:
+                    # Other attrbute not handled
+                    cookie[attr] = val
+                else:
+                    # Other name-only attrbute not handled
+                    cookie[attr] = True
+
+            yield cookie
+
+    def extract_header(self, request_host, request_uri, header):
+        """Extract cookies from HTTP-style header(Set-Cookie) and save them
+        to cookie jar.
+
+        For an expired cookie, just save it and overwrite the old one to
+        disable the cookie.
+        """
+        for cookie in self.parse_iter(header):
+            domain = cookie.get("domain", request_host)
+            path = cookie.get("path", os.path.dirname(request_uri))
+
+            cookie = Cookie.create(
+                cookie["name"],
+                cookie["value"],
+                domain,
+                path,
+                cookie.get("max_age"),
+                cookie.get("expires"),
+                cookie.get("secure"),
+            )
+
+            self.set(cookie)
+
+
+class NullCookieJar(object):
+    def __init__(self):
+        pass
+
+    def load(self, filename):
+        pass
+
+    def save(self, filename):
+        pass
+
+    def set(self, cookie, value=None, **kwargs):
+        pass
+
+    def get(self, domain=None, path=None, name=None):
+        return []
+
+    def iter(self, domain=None, path=None):
+        return
+        yield
+
+    def clear(self, domain=None, path=None, name=None):
+        pass
+
+    def get_header(self, request_host, request_uri, is_https):
+        return ""
+
+    @staticmethod
+    def parse_iter(header):
+        return
+        yield
+
+    def extract_header(self, request_host, request_uri, header):
+        pass

--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -1560,14 +1560,13 @@ class Http(object):
         self.credentials.clear()
         self.authorizations = []
 
-    def _set_cookie_header(
-            self, headers, request_host, request_uri, is_https, cookies):
+    def _set_cookie_header(self, headers, host, uri, is_https, cookies):
         # Add one-time cookies provided by request parameter
-        cookie_list = ['{0}={1}'.format(n, v) for n, v in cookies.items()]
+        cookie_list = ['{0}={1}'.format(n, v) for n, v in cookies.items()] \
+            if cookies else []
 
         # Add the cookies matched in cookie jar
-        cookie_header = self.cookie_jar.get_header(
-            request_host, request_uri, is_https)
+        cookie_header = self.cookie_jar.get_header(host, uri, is_https)
         if cookie_header:
             cookie_list.append(cookie_header)
 
@@ -1873,8 +1872,7 @@ class Http(object):
             if "range" not in headers and "accept-encoding" not in headers:
                 headers["accept-encoding"] = "gzip, deflate"
 
-            self._set_cookie_header(headers, conn.host, request_uri,
-                                    scheme == 'https', cookies or {})
+            self._set_cookie_header(headers, conn.host, request_uri, scheme == 'https', cookies)
 
             info = email.message.Message()
             cachekey = None

--- a/python3/httplib2/cookie.py
+++ b/python3/httplib2/cookie.py
@@ -252,9 +252,8 @@ class CookieJar(object):
                 del self._cookies[domain]
             except KeyError:
                 pass
-            return
         else:
-            self._cookies = {}
+            self._cookies.clear()
 
         if self.filename:
             self.save(self.filename)

--- a/python3/httplib2/cookie.py
+++ b/python3/httplib2/cookie.py
@@ -1,0 +1,397 @@
+import os
+import re
+import time
+import email
+import calendar
+from collections import namedtuple
+
+
+RE_SPLIT_COOKIE = re.compile(r"(?:,)\s*(?=[^;, ]*?=[^;, ]*)")
+
+
+CookieBase = namedtuple("Cookie", ["name", "value", "domain", "path", "expires", "secure"])
+
+
+class Cookie(CookieBase):
+    """Represent a Cookie with all attributes."""
+
+    def is_expired(self):
+        return self.expires and (time.time() >= self.expires)
+
+    @staticmethod
+    def normalize_path(path):
+        # A normal cookie path always starts with / and ends with /
+        path = path or "/"
+        if not path.startswith("/"):
+            path = "/" + path
+
+        if not path.endswith("/"):
+            path += "/"
+        return path
+
+    @staticmethod
+    def create(name, value, domain=None, path=None, max_age=None, expires=None, secure=False):
+        """Create a cookie by the given attributes.
+
+        domain:
+            Host to which the cookie will be sent.
+
+            Dot(.) is a special domain in httplib2, that indicates the cookie
+            can be used over all domains. It's also the default value if the
+            domain is not specified.
+
+        path:
+            Path to which the cookie will be sent. The default path is "/" if
+            not specified.
+
+        max_age:
+            Number of seconds until the cookie expires. A zero or negative
+            number will expire the cookie immediately.
+
+            max_age has higher priority than 'expires' date.
+
+        expires:
+            The maximum lifetime of the cookie as an HTTP-date timestamp.
+            Format:
+                <day-name>, <day> <month> <year> <hour>:<minute>:<second> GMT
+            Example: Wed, 21 Oct 2015 07:28:00 GMT
+
+        secure:
+            A secure cookie is only sent to the server when a request is made
+            with the https: scheme. False by default.
+        """
+        if max_age is not None:
+            expires = time.time() + int(max_age)
+        elif expires is not None:
+            expires = calendar.timegm(email.utils.parsedate_tz(expires))
+        else:
+            expires = None
+
+        domain = domain or "."
+        path = Cookie.normalize_path(path)
+
+        return Cookie(name, value, domain, path, expires, secure)
+
+
+class CookieJar(object):
+    """Store and manipulate HTTP Cookies."""
+
+    def __init__(self, init_cookies=None, filename=None):
+        """
+        init_cookies:
+            A dict of cookies {<name>: <value>} to initialize the cookie jar.
+            These cookies are suitable for use over all domains and paths and
+            never expire.
+
+        filename:
+            Cookie file to be loaded and saved. The file will be kept updating
+            when any cookies are added or deleted.
+        """
+
+        # Cookies are stored in hierarchy: domain > path > name > cookie
+        self._cookies = {}
+
+        self.filename = filename
+        if filename and os.path.isfile(filename):
+            self.load(filename)
+
+        for name, value in (init_cookies or {}).items():
+            cookie = Cookie.create(name, value)
+            self.set(cookie)
+
+    def load(self, filename):
+        """Load cookies from file.
+
+        Cookie file format spec:
+            https://curl.haxx.se/docs/http-cookies.html
+        """
+        with open(filename, "rt") as fd:
+            for line in fd:
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue  # blank line
+
+                domain, _, path, secure, expires, name, value = line.split("\t")
+
+                expires = int(expires) if expires else None
+                secure = secure == "TRUE"
+
+                cookie = Cookie(name, value, domain, path, expires, secure)
+
+                cookielist = self._cookies.setdefault(domain, {}).setdefault(path, {})
+                cookielist[name] = cookie
+
+    def save(self, filename):
+        """Save cookies to file.
+
+        Cookie file format spec:
+            https://curl.haxx.se/docs/http-cookies.html
+
+        Note that global cookies (domain attribute is dot) will not be saved.
+        """
+        file_header = """\
+# Netscape HTTP Cookie File
+# https://curl.haxx.se/docs/http-cookies.html
+# This is a generated file! Do not edit.
+
+"""
+        with open(filename, "wt") as fd:
+            fd.write(file_header)
+
+            for cookie in self.iter():
+                if cookie.is_expired() or cookie.domain == ".":
+                    continue
+
+                secure = "TRUE" if cookie.secure else "FALSE"
+                with_subdomain = "TRUE" if cookie.domain.startswith(".") else "FALSE"
+
+                if cookie.expires is not None:
+                    expires = str(int(cookie.expires))
+                else:
+                    expires = ""
+
+                cookie_line = "\t".join(
+                    [cookie.domain, with_subdomain, cookie.path, secure, expires, cookie.name, cookie.value]
+                )
+                fd.write(cookie_line + "\n")
+
+    def set(self, cookie, value=None, **kwargs):
+        """Put a new cookie or update the existing cookie to this cookie jar.
+
+        cookie:
+            Either a cookie name or cookie object.
+            In case it's a cookie name, the value must be provided. And other
+            optional parameters are the same as Cookie.create().
+        """
+        if not isinstance(cookie, Cookie):
+            assert cookie is not None and value is not None, "name and value must be given to create a cookie"
+            cookie = Cookie.create(cookie, value, **kwargs)
+        path_cookies = self._cookies.setdefault(cookie.domain, {}).setdefault(cookie.path, {})
+        path_cookies[cookie.name] = cookie
+
+        if self.filename and cookie.domain != ".":
+            self.save(self.filename)
+
+    def get(self, domain=None, path=None, name=None):
+        """Get cookies filtered by domain, path or name
+
+        If one parameter is specified, the preceding parameter(s) must also
+        be specified.
+
+        If name is specified, only returns the cookie with that name.
+        Otherwise, return a cookie list.
+
+        Return KeyError if no matching cookie found.
+        """
+        if name is not None:
+            assert domain and path, "domain and path must be given to get a cookie by name"
+            path = Cookie.normalize_path(path)
+            return self._cookies[domain][path][name]
+
+        if path is not None:
+            assert domain, "domain must be given to get cookies by path"
+            path = Cookie.normalize_path(path)
+            path_cookies = self._cookies[domain][path]
+            return list(path_cookies.values())
+
+        if domain is not None:
+            return [ck for pc in self._cookies[domain].values() for ck in pc.values()]
+
+        return [ck for dc in self._cookies.values() for pc in dc.values() for ck in pc.values()]
+
+    def iter(self, domain=None, path=None):
+        """Return an iterator of cookies filtered by domain, path.
+
+        If domain and path are not specified, all cookies are returned.
+
+        Raise KeyError if no matching cookie found.
+        """
+        if path is not None:
+            assert domain, "domain must be given to get cookies by path"
+            path = Cookie.normalize_path(path)
+            for ck in self._cookies[domain][path].values():
+                yield ck
+            return
+
+        if domain is not None:
+            for pc in self._cookies[domain].values():
+                for ck in pc.values():
+                    yield ck
+            return
+
+        for dc in self._cookies.values():
+            for pc in dc.values():
+                for ck in pc.values():
+                    yield ck
+
+    def clear(self, domain=None, path=None, name=None):
+        """Delete cookies by domain, path, or name.
+
+        If one parameter is specified, the preceding parameter(s) must also
+        be specified.
+
+        No error if no matching cookie found.
+        """
+        try:
+            if name is not None:
+                assert domain and path, "domain and path must be given to remove a cookie by name"
+                path = Cookie.normalize_path(path)
+                del self._cookies[domain][path][name]
+                return
+
+            if path is not None:
+                assert domain, "domain must be given to remove cookies by path"
+                path = Cookie.normalize_path(path)
+                del self._cookies[domain][path]
+                return
+
+            if domain is not None:
+                del self._cookies[domain]
+                return
+        except KeyError:
+            return
+
+        self._cookies = {}
+
+        if self.filename:
+            self.save()
+
+    def _match_path(self, request_uri, cookie_path):
+        return cookie_path[:-1] == request_uri or request_uri.startswith(cookie_path)
+
+    def _match_domain(self, request_host, cookie_domain):
+        if cookie_domain.startswith("."):
+            return cookie_domain == "." or request_host.endswith(cookie_domain)
+        return request_host == cookie_domain
+
+    def get_header(self, request_host, request_uri, is_https):
+        """Get the Cookie header to be applied to the request."""
+        cookie_header = []
+
+        for domain, domain_cookies in self._cookies.items():
+            if not self._match_domain(request_host, domain):
+                continue
+
+            for path, cookies in domain_cookies.items():
+                if not self._match_path(request_uri, path):
+                    continue
+
+                for cookie in cookies.values():
+                    if cookie.is_expired():
+                        continue
+
+                    if cookie.secure and not is_https:
+                        continue
+
+                    cookie_header.append("{0}={1}".format(cookie.name, cookie.value))
+
+        return "; ".join(cookie_header)
+
+    @staticmethod
+    def parse_iter(header):
+        """An iterator to parse cookies in HTTP-style header(Set-Cookie).
+
+        cookie header example:
+            sid=vBj3zbrmgynsZ8ggVpmSIOc9bXAueT3z; HttpOnly;
+
+        It may contain multiple cookies separated by comma(RFC 2109).
+
+        Example:
+            BD_NOT_HTTPS=1; path=/; Max-Age=300, BIDUPSID=D2504FE922735DE;
+            expires=Thu, 31-Dec-37 23:55:55 GMT; max-age=2147483647; path=/;
+            domain=.example.com, PSTM=1595329370
+
+        The 'expires' also contains comma. Be careful!
+        """
+        if not header:
+            return
+
+        for cookie_str in RE_SPLIT_COOKIE.split(header):
+            cookie, *attribute_list = cookie_str.split(";")
+            name, value = cookie.split("=")
+            cookie = {"name": name, "value": value}
+
+            for attr_str in attribute_list:
+                attr, *val = attr_str.split("=", 1)
+                attr = attr.strip()
+                attr_l = attr.lower()
+
+                if attr_l == "max-age":
+                    cookie["max_age"] = val[0]
+                elif attr_l == "expires":
+                    cookie["expires"] = val[0]
+                elif attr_l == "domain":
+                    domain = val[0].lower()
+                    if not domain.startswith("."):
+                        domain = "." + domain
+                    cookie["domain"] = domain
+                elif attr_l == "path":
+                    cookie["path"] = val[0]
+                elif attr_l == "secure":
+                    cookie["secure"] = True
+                elif val:
+                    # Other attrbute not handled
+                    cookie[attr] = val[0]
+                else:
+                    # Other name-only attrbute not handled
+                    cookie[attr] = True
+
+            yield cookie
+
+    def extract_header(self, request_host, request_uri, header):
+        """Extract cookies from HTTP-style header(Set-Cookie) and save them
+        to cookie jar.
+
+        For an expired cookie, just save it and overwrite the old one to
+        disable the cookie.
+        """
+        for cookie in self.parse_iter(header):
+            domain = cookie.get("domain", request_host)
+            path = cookie.get("path", os.path.dirname(request_uri))
+
+            cookie = Cookie.create(
+                cookie["name"],
+                cookie["value"],
+                domain,
+                path,
+                cookie.get("max_age"),
+                cookie.get("expires"),
+                cookie.get("secure"),
+            )
+
+            self.set(cookie)
+
+
+class NullCookieJar(object):
+    def __init__(self):
+        pass
+
+    def load(self, filename):
+        pass
+
+    def save(self, filename):
+        pass
+
+    def set(self, cookie, value=None, **kwargs):
+        pass
+
+    def get(self, domain=None, path=None, name=None):
+        return []
+
+    def iter(self, domain=None, path=None):
+        return
+        yield
+
+    def clear(self, domain=None, path=None, name=None):
+        pass
+
+    def get_header(self, request_host, request_uri, is_https):
+        return ""
+
+    @staticmethod
+    def parse_iter(header):
+        return
+        yield
+
+    def extract_header(self, request_host, request_uri, header):
+        pass

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,10 @@ A comprehensive HTTP client library, ``httplib2`` supports many features left ou
   and memcached based caches are supported.
 
 
+**Cookies**
+  Handles cookies both in request and response. Automatically manages the cookies expiration, follows the cookies domain and path matching policy.
+
+
 **All Methods**
   The module can handle any HTTP request method, not just GET and POST.
 

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -1,0 +1,496 @@
+import httplib2
+from httplib2.cookie import Cookie
+import pytest
+import socket
+import tests
+from six.moves import urllib
+from datetime import datetime, timedelta
+import time
+
+
+@pytest.fixture
+def cookie_jar():
+    cj = httplib2.CookieJar({'g_a': '1', 'g_b': '2', 'g_c': '3'})
+    cj.set('aaa', '111', domain='example.com', max_age=10000)
+    cj.set('bbb', '222', domain='.example.com', secure=True)
+    cj.set('ccc', '333', domain='.example.com', path='/dir_a', secure=True)
+    cj.set('ddd', '444', domain='.example.com', path='/dir_b/dir_c')
+    yield cj
+    cj.clear()
+
+
+@pytest.fixture
+def cookie_file(tmpdir, cookie_jar):
+    d = tmpdir.join("cookie.txt")
+    cookie_jar.save(str(d))
+    yield str(d)
+
+
+# Test Cookie Jar
+def test_cookie_jar_basic():
+    """Test making cookies and set, get cookies from cookiejar."""
+    cj = httplib2.CookieJar()
+    assert cj.get() == []
+
+    cookie1 = Cookie.create('abc', '123', 'example.com')
+    cj.set(cookie1)
+
+    cookie2 = Cookie.create('def', '456', '.example.com', '/dir_a', max_age=0)
+    cj.set(cookie2)
+
+    expires = (datetime.utcnow() + timedelta(seconds=5)).strftime("%a, %d %b %Y %H:%M:%S GMT")
+    cookie3 = Cookie.create('ghi', '789', '.example.com', '/dir_b', expires=expires)
+    cj.set(cookie3)
+
+    # A global and secure
+    cookie4 = Cookie.create('jkl', '000', secure=True)
+    cj.set(cookie4)
+
+    assert len(cj.get()) == 4
+    assert cj.get('example.com') == [cookie1]
+    assert cj.get('example.com', '/') == [cookie1]
+    assert cj.get('example.com', '/', 'abc') == cookie1
+    assert set(cj.get('.example.com')) == {cookie2, cookie3}
+    assert cj.get('.example.com', '/dir_b') == [cookie3]
+    assert cj.get('.') == [cookie4]
+
+    with pytest.raises(KeyError):
+        cj.get('example.com', '/', '123')
+
+
+def test_cookie_jar_expire():
+    """Test expired cookie."""
+    cookie = Cookie.create('abc', '123', max_age=5)
+    assert not cookie.is_expired()
+
+    # a cookie with max_age 0 or negtive will expire the cookie immeditely
+    cookie = Cookie.create('abc', '123', max_age=0)
+    assert cookie.is_expired()
+
+    cookie = Cookie.create('abc', '123', max_age=-1)
+    assert cookie.is_expired()
+
+    expires = (datetime.utcnow() + timedelta(seconds=5)).strftime("%a, %d %b %Y %H:%M:%S GMT")
+    cookie = Cookie.create('abc', '123', expires=expires)
+    assert not cookie.is_expired()
+
+    expires = (datetime.utcnow() - timedelta(seconds=1)).strftime("%a, %d %b %Y %H:%M:%S GMT")
+    cookie = Cookie.create('abc', '123', expires=expires)
+    assert cookie.is_expired()
+
+
+def test_cookie_jar_init_with_cookies():
+    """Initialize the cookie jar with global cookies."""
+    cj = httplib2.CookieJar({'a': '1', 'b': '2', 'c': '3'})
+    assert len(cj.get()) == 3
+    assert len(cj.get('.')) == 3
+    assert len(cj.get('.', '/')) == 3
+
+
+def test_cookie_jar_auto_persistence(tmpdir):
+    """Initialize the cookie jar with cookie file."""
+    d = tmpdir.join("cookie.txt")
+    cj = httplib2.CookieJar({'a': '1', 'b': '2', 'c': '3'}, filename=str(d))
+
+    cookie = Cookie.create('abc', '123', 'example.com')
+    cj.set(cookie)
+    assert len(cj.get()) == 4
+
+    cj = httplib2.CookieJar(filename=str(d))
+    assert len(cj.get()) == 1
+
+    cj = httplib2.CookieJar({'a': 1}, filename=str(d))
+    assert len(cj.get()) == 2
+
+
+def test_cookie_jar_manual_persistence(cookie_file):
+    """Save cookies to cookie file and load them back."""
+    cj = httplib2.CookieJar()
+    assert cj.get() == []
+
+    cj.load(cookie_file)
+    assert len(cj.get()) == 4
+
+    cj.set(Cookie.create('username', 'john'))  # global cookie
+    cj.set(Cookie.create('password', '123456', 'example.com'))
+    assert len(cj.get()) == 6
+
+    cj.save(cookie_file)
+    cj.load(cookie_file)
+    assert len(cj.get()) == 6
+
+    # the global cookies are cleared
+    cj.clear()
+    cj.load(cookie_file)
+    assert len(cj.get()) == 5
+
+    cookie = cj.get('.example.com', '/dir_a', 'ccc')
+    assert cookie.name == 'ccc'
+    assert cookie.value == '333'
+    assert cookie.domain == '.example.com'
+    assert cookie.path == '/dir_a/'
+    assert cookie.expires is None
+    assert cookie.secure
+
+
+def test_cookie_jar_iter(cookie_jar):
+    """Test cookie iterator"""
+    count = 0
+    for cookie in cookie_jar.iter():
+        count += 1
+    assert count == 7
+
+    count = 0
+    for cookie in cookie_jar.iter('example.com'):
+        count += 1
+    assert count == 1
+
+    count = 0
+    for cookie in cookie_jar.iter('.example.com', '/dir_a'):
+        count += 1
+    assert count == 1
+
+    with pytest.raises(KeyError):
+        for cookie in cookie_jar.iter('.example2.com'):
+            pass
+
+    with pytest.raises(KeyError):
+        for cookie in cookie_jar.iter('.example.com', '/dir_c'):
+            pass
+
+
+def test_cookie_jar_clear(cookie_jar):
+    """Test clear the cookies in cookie jar"""
+
+    # Clear a non-existing cookie won't raise exception
+    cookie_jar.clear('.example2.com')
+    assert len(cookie_jar.get()) == 7
+
+    # Clear cookies by domain and path
+    cookie_jar.clear('.example.com', '/dir_a')
+    assert len(cookie_jar.get()) == 6
+
+    # Clear global cookies
+    cookie_jar.clear('.')
+    assert len(cookie_jar.get()) == 3
+
+    # Clear all cookies
+    cookie_jar.clear()
+    assert len(cookie_jar.get()) == 0
+
+
+def test_cookie_jar_get_header(cookie_jar):
+    """Test getting the HTTP Cookie header from cookie jar"""
+    header = cookie_jar.get_header('example.com', '/a/b/c', False)
+    assert set(header.split('; ')) == {'g_a=1', 'g_b=2', 'g_c=3', 'aaa=111'}
+
+    header = cookie_jar.get_header('a.example.com', '/dir_a', False)
+    assert set(header.split('; ')) == {'g_a=1', 'g_b=2', 'g_c=3'}
+
+    header = cookie_jar.get_header('a.example.com', '/dir_a/c/d/e', False)
+    assert set(header.split('; ')) == {'g_a=1', 'g_b=2', 'g_c=3'}
+
+    header = cookie_jar.get_header('a.example.com', '/dir_a', True)
+    assert set(header.split('; ')) == {'g_a=1', 'g_b=2', 'g_c=3', 'bbb=222', 'ccc=333'}
+
+    header = cookie_jar.get_header('a.example.com', '/dir_a/c/d/e', True)
+    assert set(header.split('; ')) == {'g_a=1', 'g_b=2', 'g_c=3', 'bbb=222', 'ccc=333'}
+
+    header = cookie_jar.get_header('a.example.com', '/dir_b/dir_c/d/e', True)
+    assert set(header.split('; ')) == {'g_a=1', 'g_b=2', 'g_c=3', 'bbb=222', 'ddd=444'}
+
+    cookie_jar.set(Cookie.create('abc', '123', '.example.com', '/dir_a', max_age=5))
+    header = cookie_jar.get_header('a.example.com', '/dir_a/c/d/e', True)
+    assert set(header.split('; ')) == {'g_a=1', 'g_b=2', 'g_c=3', 'bbb=222', 'ccc=333', 'abc=123'}
+
+    # Wait for the cookie expired
+    time.sleep(5)
+    header = cookie_jar.get_header('a.example.com', '/dir_a/c/d/e', True)
+    assert set(header.split('; ')) == {'g_a=1', 'g_b=2', 'g_c=3', 'bbb=222', 'ccc=333'}
+
+    cookie_jar.clear()
+    header = cookie_jar.get_header('a.example.com', '/dir_a/c/d/e', True)
+    assert header == ''
+
+
+def test_cookie_jar_parse_iter():
+    """Test parsing cookies from HTTP Set-Cookie header."""
+    for cookie in httplib2.CookieJar.parse_iter(
+            'G=7; HttpOnly; SameSite=Strict; domain=example.com; Path=/login/a; MyAttr=1; MyAttr2'):
+
+        assert cookie['name'] == 'G'
+        assert cookie['value'] == '7'
+        assert cookie['domain'] == '.example.com'
+        assert cookie['path'] == '/login/a'
+        assert cookie['HttpOnly'] is True
+        assert cookie['SameSite'] == "Strict"
+        # custom cookie attribute in the header
+        assert cookie['MyAttr'] == '1'
+        assert cookie['MyAttr2'] is True
+
+    for cookie in httplib2.CookieJar.parse_iter('A=1,B=2,C=3'):
+        assert cookie['name'] in 'ABC'
+
+
+def test_cookie_jar_extract_header():
+    """Test extracting cookies from HTTP Set-Cookie header to cookie jar"""
+    cj = httplib2.CookieJar()
+    cj.extract_header('www.example.com', '/login.cgi', 'A=1;Max-Age=100')
+    assert len(cj.get()) == 1
+
+    cj.extract_header('www.example.com', '/login.cgi', 'B=2; Max-Age=100,C=3, D=4')
+    assert len(cj.get()) == 4
+
+    cj.extract_header('www.example.com', '/login.cgi', 'A=1;Max-Age=0')
+    assert len(cj.get()) == 4
+
+    cj.extract_header('www.example.com', '/login.cgi', 'E=5; Expires=Wed, 21 Oct 2015 07:28:00 GMT;Max-Age=0')
+    assert cj.get('www.example.com', '/', 'E').is_expired()
+
+    expires = (datetime.utcnow() + timedelta(seconds=5)).strftime("%a, %d %b %Y %H:%M:%S GMT")
+    cj.extract_header('www.example.com', '/login/login.cgi',
+                      'F=6; Expires={}; Secure; HttpOnly; SameSite=Strict'.format(expires))
+    cookie = cj.get('www.example.com', '/login', 'F')
+    assert cookie.secure
+    assert cookie.domain == 'www.example.com'
+    assert cookie.path == '/login/'
+    assert not cookie.is_expired()
+
+    cj.extract_header('www.example.com', '/login/login.cgi',
+                      'G=7; HttpOnly; SameSite=Strict; domain=example.com; Path=/login/a')
+    cookie = cj.get('.example.com', '/login/a', 'G')
+    assert not cookie.secure
+    assert cookie.domain == '.example.com'
+    assert cookie.path == '/login/a/'
+    assert not cookie.is_expired()
+
+    cj.extract_header('www.example.com', '/login.cgi', '')
+    assert len(cj.get()) == 7
+
+
+# Test Cookie Manager
+@pytest.fixture
+def cookie_http():
+    cj = httplib2.CookieJar()
+    http = httplib2.Http(cookie_jar=cj)
+    yield http
+    http.close()
+
+
+@pytest.fixture
+def cookie_http2(cookie_jar):
+    http = httplib2.Http(cookie_jar=cookie_jar)
+    yield http
+    http.close()
+
+
+SET_COOKIE_HEADERS = (
+    "A=1; Max-Age=100,B=2, C=3",
+    ("A=1; Max-Age=100", "B=2", "C=3")
+)
+
+
+@pytest.mark.parametrize("cookie_header", SET_COOKIE_HEADERS, ids=["single", "multiple"])
+def test_response_cookie_attribute(cookie_header):
+    """ Test the attribute 'cookies' in Response object."""
+    http = httplib2.Http()
+
+    with tests.server_const_http(headers={'set-cookie': cookie_header}) as uri:
+        response, _ = http.request(uri, "GET")
+        assert len(response.cookies) == 3
+        assert response.cookies['A'] == '1'
+        assert response.cookies['B'] == '2'
+        assert response.cookies['C'] == '3'
+
+
+def test_onetime_cookie():
+    http = httplib2.Http()
+    cookies = {'AAA': '111', 'BBB': '222'}
+    handler = tests.http_reflect_with_cookies()
+
+    with tests.server_request(handler) as uri:
+        response, content = http.request(
+            uri, "GET", body="this request have one time cookie", cookies=cookies)
+        assert response.status == 200
+        assert dict([ck.split('=') for ck in content.decode().split('; ')]) == cookies
+
+
+@pytest.mark.parametrize("cookie_header", SET_COOKIE_HEADERS, ids=["single", "multiple"])
+def test_cookie_manager_enabled(cookie_header, cookie_http):
+    print(cookie_header)
+    handler = tests.http_reflect_with_cookies({'/login': cookie_header})
+
+    with tests.server_request(handler, request_count=2) as uri:
+        login_url = urllib.parse.urljoin(uri, "/login")
+        response, content = cookie_http.request(login_url, "POST", body="this is a login request")
+        assert response.status == 200
+        assert len(response.cookies) == 3
+
+        op_url = urllib.parse.urljoin(uri, "/op")
+        response, content = cookie_http.request(op_url, "POST", body="this is an op request")
+        assert response.status == 200
+
+        if isinstance(cookie_header, (list, tuple)):
+            cookie_header = ', '.join(cookie_header)
+        set_cookies = {ck['name']: ck['value'] for ck in httplib2.CookieJar.parse_iter(cookie_header)}
+        assert dict([ck.split('=') for ck in content.decode().split('; ')]) == set_cookies
+
+
+def test_cookie_manager_expire(cookie_http):
+    expires = (datetime.utcnow() + timedelta(seconds=10)).strftime("%a, %d %b %Y %H:%M:%S GMT")
+    cookie_header = ('A=1', 'B=2; Max-Age=5', 'C=3; Expires={}'.format(expires))
+    handler = tests.http_reflect_with_cookies({'/login': cookie_header})
+
+    with tests.server_request(handler, request_count=4, timeout=20) as uri:
+        login_url = urllib.parse.urljoin(uri, "/login")
+        response, content = cookie_http.request(login_url, "POST", body="this is a login request")
+        assert response.status == 200
+
+        op_url = urllib.parse.urljoin(uri, "/op")
+        response, content = cookie_http.request(op_url, "POST", body="op request 1")
+        assert response.status == 200
+
+        time.sleep(5)
+        response, content = cookie_http.request(op_url, "POST", body="op reques 2")
+        assert response.status == 200
+        set_cookies = {'A': '1', 'C': '3'}
+        assert dict([ck.split('=') for ck in content.decode().split('; ')]) == set_cookies
+
+        time.sleep(5)
+        response, content = cookie_http.request(op_url, "POST", body="op reques 3")
+        assert response.status == 200
+        set_cookies = {'A': '1'}
+        assert dict([ck.split('=') for ck in content.decode().split('; ')]) == set_cookies
+
+
+class HttpConnectionWithDNSResolve(httplib2.HTTPConnectionWithTimeout):
+
+    def connect(self):
+        host = 'localhost' if self.host.endswith('.example.com') else self.host
+        self.sock = self._create_connection(
+            (host, self.port), self.timeout, self.source_address)
+        self.sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+
+
+def test_cookie_manager_match(cookie_http):
+    # httplib2 client always initiates new connection for new host name.
+    # Close the connection after request so server_socket can accept the next
+    # request.
+    headers = {'connection': 'close'}
+    handler = tests.http_reflect_with_cookies({
+        '/login': ('A=1; domain=example.com', 'B=2; Domain=example.com; Max-Age=100', 'C=3'),
+        '/login2': 'D=4; domain=example.com; path=/path_a',
+        '/path_a/path_b/login3': 'E=5; domain=example.com'  # test default path
+    }, response_headers=headers)
+
+    with tests.server_request(handler, request_count=8, timeout=30) as uri:
+        login_url = urllib.parse.urljoin(uri, "/login")
+        response, content = cookie_http.request(
+            login_url, "POST", body="this is a login request",
+            connection_type=HttpConnectionWithDNSResolve)
+        assert response.status == 200
+
+        url_parsed = urllib.parse.urlparse(uri)
+        netloc = 'a.example.com:' + str(url_parsed.port)
+        example_url = urllib.parse.urlunparse((
+            url_parsed.scheme, netloc, url_parsed.path, url_parsed.params, url_parsed.query, url_parsed.fragment
+        ))
+        op_url = urllib.parse.urljoin(example_url, "/op")
+        response, content = cookie_http.request(
+            op_url, "POST", body="op request 1",
+            connection_type=HttpConnectionWithDNSResolve)
+        assert response.status == 200
+        expect_cookies = {'A': '1', 'B': '2'}
+        assert dict([ck.split('=') for ck in content.decode().split('; ')]) == expect_cookies
+
+        login2_url = urllib.parse.urljoin(uri, "/login2")
+        response, content = cookie_http.request(
+            login2_url, "POST", body="this is a login request",
+            connection_type=HttpConnectionWithDNSResolve)
+        assert response.status == 200
+
+        op_url = urllib.parse.urljoin(example_url, "/path_a/op?vvv=yes")
+        response, content = cookie_http.request(
+            op_url, "POST", body="op request 2",
+            connection_type=HttpConnectionWithDNSResolve)
+        assert response.status == 200
+        expect_cookies = {'A': '1', 'B': '2', 'D': '4'}
+        assert dict([ck.split('=') for ck in content.decode().split('; ')]) == expect_cookies
+
+        op_url = urllib.parse.urljoin(example_url, "/path_b/op?vvv=yes")
+        response, content = cookie_http.request(
+            op_url, "POST", body="op request 3",
+            connection_type=HttpConnectionWithDNSResolve)
+        assert response.status == 200
+        expect_cookies = {'A': '1', 'B': '2'}
+        assert dict([ck.split('=') for ck in content.decode().split('; ')]) == expect_cookies
+
+        login3_url = urllib.parse.urljoin(uri, "/path_a/path_b/login3")
+        response, content = cookie_http.request(
+            login3_url, "POST", body="this is a login request",
+            connection_type=HttpConnectionWithDNSResolve)
+        assert response.status == 200
+
+        op_url = urllib.parse.urljoin(example_url, "/path_a/op?vvv=yes")
+        response, content = cookie_http.request(
+            op_url, "POST", body="op request 4",
+            connection_type=HttpConnectionWithDNSResolve)
+        assert response.status == 200
+        expect_cookies = {'A': '1', 'B': '2', 'D': '4'}
+        assert dict([ck.split('=') for ck in content.decode().split('; ')]) == expect_cookies
+
+        op_url = urllib.parse.urljoin(example_url, "/path_a/path_b/op")
+        response, content = cookie_http.request(
+            op_url, "POST", body="op request 5",
+            connection_type=HttpConnectionWithDNSResolve)
+        assert response.status == 200
+        expect_cookies = {'A': '1', 'B': '2', 'D': '4', 'E': '5'}
+        assert dict([ck.split('=') for ck in content.decode().split('; ')]) == expect_cookies
+
+
+def test_cookie_manager_with_onetime_cookie(cookie_http2):
+    cookies = {'AAA': '111', 'BBB': '222'}
+    handler = tests.http_reflect_with_cookies()
+
+    with tests.server_request(handler) as uri:
+        url_parsed = urllib.parse.urlparse(uri)
+        netloc = 'a.example.com:' + str(url_parsed.port)
+        example_url = urllib.parse.urlunparse((
+            url_parsed.scheme, netloc, url_parsed.path, url_parsed.params, url_parsed.query, url_parsed.fragment
+        ))
+        url = urllib.parse.urljoin(example_url, "/dir_b/dir_c/op")
+        response, content = cookie_http2.request(
+            url, "GET", body="this request include cookies from both one-time cookies and cookie jar",
+            connection_type=HttpConnectionWithDNSResolve, cookies=cookies)
+        assert response.status == 200
+        expect_cookies = {'g_a': '1', 'g_b': '2', 'g_c': '3', 'AAA': '111', 'BBB': '222', 'ddd': '444'}
+        assert dict([ck.split('=') for ck in content.decode().split('; ')]) == expect_cookies
+
+
+@pytest.mark.parametrize("redirect_code", httplib2.REDIRECT_CODES)
+def test_cookie_following_30x_redirect(redirect_code, cookie_http):
+    # Test that the cookies are automatically follow 301 redirects
+    cookie_http.follow_all_redirects = True
+
+    # Python2.x httplib doesn't have this code.
+    status_code = "308 Permanent Redirect" if redirect_code == 308 else redirect_code
+    routes = {
+        "": tests.http_response_bytes(
+            status=status_code,
+            headers={
+                'set-cookie': ('A=1; Max-Age=100', 'B=2'),
+                'location': "/final"
+            },
+            body=b"set-cookie header sent"
+        ),
+        "/final": tests.http_reflect_with_cookies()
+    }
+    with tests.server_route(routes, request_count=2) as uri:
+        response, content = cookie_http.request(uri, "GET")
+
+    assert response.status == 200
+    destination = urllib.parse.urljoin(uri, "/final")
+    assert response["content-location"] == destination
+    assert response.previous.status == redirect_code
+    expect_cookies = {'A': '1', 'B': '2'}
+    assert dict([ck.split('=') for ck in content.decode().split('; ')]) == expect_cookies

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -335,13 +335,13 @@ def test_cookie_manager_enabled(cookie_header, cookie_http):
 
         if isinstance(cookie_header, (list, tuple)):
             cookie_header = ", ".join(cookie_header)
-        set_cookies = {ck["name"]: ck["value"] for ck in httplib2.CookieJar.parse_iter(cookie_header)}
-        assert dict([ck.split("=") for ck in content.decode().split("; ")]) == set_cookies
+        expect_cookies = {ck["name"]: ck["value"] for ck in httplib2.CookieJar.parse_iter(cookie_header)}
+        assert dict([ck.split("=") for ck in content.decode().split("; ")]) == expect_cookies
 
 
 def test_cookie_manager_expire(cookie_http):
-    expires = (datetime.utcnow() + timedelta(seconds=10)).strftime("%a, %d %b %Y %H:%M:%S GMT")
-    cookie_header = ("A=1", "B=2; Max-Age=5", "C=3; Expires={}".format(expires))
+    expires = (datetime.utcnow() + timedelta(seconds=2)).strftime("%a, %d %b %Y %H:%M:%S GMT")
+    cookie_header = ("A=1", "B=2; Max-Age=1", "C=3; Expires={}".format(expires))
     handler = tests.http_reflect_with_cookies({"/login": cookie_header})
 
     with tests.server_request(handler, request_count=4, timeout=20) as uri:
@@ -353,17 +353,17 @@ def test_cookie_manager_expire(cookie_http):
         response, content = cookie_http.request(op_url, "POST", body="op request 1")
         assert response.status == 200
 
-        time.sleep(5)
+        time.sleep(1)
         response, content = cookie_http.request(op_url, "POST", body="op reques 2")
         assert response.status == 200
-        set_cookies = {"A": "1", "C": "3"}
-        assert dict([ck.split("=") for ck in content.decode().split("; ")]) == set_cookies
+        expect_cookies = {"A": "1", "C": "3"}
+        assert dict([ck.split("=") for ck in content.decode().split("; ")]) == expect_cookies
 
-        time.sleep(5)
+        time.sleep(1)
         response, content = cookie_http.request(op_url, "POST", body="op reques 3")
         assert response.status == 200
-        set_cookies = {"A": "1"}
-        assert dict([ck.split("=") for ck in content.decode().split("; ")]) == set_cookies
+        expect_cookies = {"A": "1"}
+        assert dict([ck.split("=") for ck in content.decode().split("; ")]) == expect_cookies
 
 
 class HttpConnectionWithDNSResolve(httplib2.HTTPConnectionWithTimeout):

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -10,11 +10,11 @@ import time
 
 @pytest.fixture
 def cookie_jar():
-    cj = httplib2.CookieJar({'g_a': '1', 'g_b': '2', 'g_c': '3'})
-    cj.set('aaa', '111', domain='example.com', max_age=10000)
-    cj.set('bbb', '222', domain='.example.com', secure=True)
-    cj.set('ccc', '333', domain='.example.com', path='/dir_a', secure=True)
-    cj.set('ddd', '444', domain='.example.com', path='/dir_b/dir_c')
+    cj = httplib2.CookieJar({"g_a": "1", "g_b": "2", "g_c": "3"})
+    cj.set("aaa", "111", domain="example.com", max_age=10000)
+    cj.set("bbb", "222", domain=".example.com", secure=True)
+    cj.set("ccc", "333", domain=".example.com", path="/dir_a", secure=True)
+    cj.set("ddd", "444", domain=".example.com", path="/dir_b/dir_c")
     yield cj
     cj.clear()
 
@@ -26,81 +26,85 @@ def cookie_file(tmpdir, cookie_jar):
     yield str(d)
 
 
-# Test Cookie Jar
 def test_cookie_jar_basic():
     """Test making cookies and set, get cookies from cookiejar."""
     cj = httplib2.CookieJar()
     assert cj.get() == []
 
-    cookie1 = Cookie.create('abc', '123', 'example.com')
+    cookie1 = Cookie.create("abc", "123", "example.com")
     cj.set(cookie1)
 
-    cookie2 = Cookie.create('def', '456', '.example.com', '/dir_a', max_age=0)
+    cookie2 = Cookie.create("def", "456", ".example.com", "/dir_a", max_age=0)
     cj.set(cookie2)
 
     expires = (datetime.utcnow() + timedelta(seconds=5)).strftime("%a, %d %b %Y %H:%M:%S GMT")
-    cookie3 = Cookie.create('ghi', '789', '.example.com', '/dir_b', expires=expires)
+    cookie3 = Cookie.create("ghi", "789", ".example.com", "/dir_b", expires=expires)
     cj.set(cookie3)
 
     # A global and secure
-    cookie4 = Cookie.create('jkl', '000', secure=True)
+    cookie4 = Cookie.create("jkl", "000", secure=True)
     cj.set(cookie4)
 
     assert len(cj.get()) == 4
-    assert cj.get('example.com') == [cookie1]
-    assert cj.get('example.com', '/') == [cookie1]
-    assert cj.get('example.com', '/', 'abc') == cookie1
-    assert set(cj.get('.example.com')) == {cookie2, cookie3}
-    assert cj.get('.example.com', '/dir_b') == [cookie3]
-    assert cj.get('.') == [cookie4]
+    assert cj.get("example.com") == [cookie1]
+    assert cj.get("example.com", "/") == [cookie1]
+    assert cj.get("example.com", "/", "abc") == cookie1
+    assert set(cj.get(".example.com")) == {cookie2, cookie3}
+    assert cj.get(".example.com", "/dir_b") == [cookie3]
+    assert cj.get(".") == [cookie4]
 
     with pytest.raises(KeyError):
-        cj.get('example.com', '/', '123')
+        cj.get("example.com", "/", "123")
 
 
 def test_cookie_jar_expire():
     """Test expired cookie."""
-    cookie = Cookie.create('abc', '123', max_age=5)
+    cookie = Cookie.create("abc", "123", max_age=5)
     assert not cookie.is_expired()
 
     # a cookie with max_age 0 or negtive will expire the cookie immeditely
-    cookie = Cookie.create('abc', '123', max_age=0)
+    cookie = Cookie.create("abc", "123", max_age=0)
     assert cookie.is_expired()
 
-    cookie = Cookie.create('abc', '123', max_age=-1)
+    cookie = Cookie.create("abc", "123", max_age=-1)
     assert cookie.is_expired()
 
     expires = (datetime.utcnow() + timedelta(seconds=5)).strftime("%a, %d %b %Y %H:%M:%S GMT")
-    cookie = Cookie.create('abc', '123', expires=expires)
+    cookie = Cookie.create("abc", "123", expires=expires)
     assert not cookie.is_expired()
 
     expires = (datetime.utcnow() - timedelta(seconds=1)).strftime("%a, %d %b %Y %H:%M:%S GMT")
-    cookie = Cookie.create('abc', '123', expires=expires)
+    cookie = Cookie.create("abc", "123", expires=expires)
     assert cookie.is_expired()
 
 
 def test_cookie_jar_init_with_cookies():
     """Initialize the cookie jar with global cookies."""
-    cj = httplib2.CookieJar({'a': '1', 'b': '2', 'c': '3'})
+    cj = httplib2.CookieJar({"a": "1", "b": "2", "c": "3"})
     assert len(cj.get()) == 3
-    assert len(cj.get('.')) == 3
-    assert len(cj.get('.', '/')) == 3
+    assert len(cj.get(".")) == 3
+    assert len(cj.get(".", "/")) == 3
 
 
 def test_cookie_jar_auto_persistence(tmpdir):
     """Initialize the cookie jar with cookie file."""
-    d = tmpdir.join("cookie.txt")
-    cj = httplib2.CookieJar({'a': '1', 'b': '2', 'c': '3'}, filename=str(d))
+    ckfile = str(tmpdir.join("cookie.txt"))
+    cj = httplib2.CookieJar({"a": "1", "b": "2", "c": "3"}, filename=ckfile)
 
-    cookie = Cookie.create('abc', '123', 'example.com')
+    cookie = Cookie.create("abc", "123", "example.com")
     cj.set(cookie)
     assert len(cj.get()) == 4
 
-    cj = httplib2.CookieJar(filename=str(d))
+    # Cookies with global domain (.) will not be saved.
+    cj = httplib2.CookieJar(filename=ckfile)
     assert len(cj.get()) == 1
 
-    cj = httplib2.CookieJar({'a': 1}, filename=str(d))
+    cj = httplib2.CookieJar({"a": 1}, filename=ckfile)
     assert len(cj.get()) == 2
+    cj.clear()
+
+    cj = httplib2.CookieJar(filename=ckfile)
+    assert len(cj.get()) == 0
 
 
 def test_cookie_jar_manual_persistence(cookie_file):
@@ -111,8 +115,8 @@ def test_cookie_jar_manual_persistence(cookie_file):
     cj.load(cookie_file)
     assert len(cj.get()) == 4
 
-    cj.set(Cookie.create('username', 'john'))  # global cookie
-    cj.set(Cookie.create('password', '123456', 'example.com'))
+    cj.set(Cookie.create("username", "john"))  # global cookie
+    cj.set(Cookie.create("password", "123456", "example.com"))
     assert len(cj.get()) == 6
 
     cj.save(cookie_file)
@@ -124,11 +128,11 @@ def test_cookie_jar_manual_persistence(cookie_file):
     cj.load(cookie_file)
     assert len(cj.get()) == 5
 
-    cookie = cj.get('.example.com', '/dir_a', 'ccc')
-    assert cookie.name == 'ccc'
-    assert cookie.value == '333'
-    assert cookie.domain == '.example.com'
-    assert cookie.path == '/dir_a/'
+    cookie = cj.get(".example.com", "/dir_a", "ccc")
+    assert cookie.name == "ccc"
+    assert cookie.value == "333"
+    assert cookie.domain == ".example.com"
+    assert cookie.path == "/dir_a/"
     assert cookie.expires is None
     assert cookie.secure
 
@@ -141,21 +145,21 @@ def test_cookie_jar_iter(cookie_jar):
     assert count == 7
 
     count = 0
-    for cookie in cookie_jar.iter('example.com'):
+    for cookie in cookie_jar.iter("example.com"):
         count += 1
     assert count == 1
 
     count = 0
-    for cookie in cookie_jar.iter('.example.com', '/dir_a'):
+    for cookie in cookie_jar.iter(".example.com", "/dir_a"):
         count += 1
     assert count == 1
 
     with pytest.raises(KeyError):
-        for cookie in cookie_jar.iter('.example2.com'):
+        for cookie in cookie_jar.iter(".example2.com"):
             pass
 
     with pytest.raises(KeyError):
-        for cookie in cookie_jar.iter('.example.com', '/dir_c'):
+        for cookie in cookie_jar.iter(".example.com", "/dir_c"):
             pass
 
 
@@ -163,15 +167,15 @@ def test_cookie_jar_clear(cookie_jar):
     """Test clear the cookies in cookie jar"""
 
     # Clear a non-existing cookie won't raise exception
-    cookie_jar.clear('.example2.com')
+    cookie_jar.clear(".example2.com")
     assert len(cookie_jar.get()) == 7
 
     # Clear cookies by domain and path
-    cookie_jar.clear('.example.com', '/dir_a')
+    cookie_jar.clear(".example.com", "/dir_a")
     assert len(cookie_jar.get()) == 6
 
     # Clear global cookies
-    cookie_jar.clear('.')
+    cookie_jar.clear(".")
     assert len(cookie_jar.get()) == 3
 
     # Clear all cookies
@@ -181,90 +185,93 @@ def test_cookie_jar_clear(cookie_jar):
 
 def test_cookie_jar_get_header(cookie_jar):
     """Test getting the HTTP Cookie header from cookie jar"""
-    header = cookie_jar.get_header('example.com', '/a/b/c', False)
-    assert set(header.split('; ')) == {'g_a=1', 'g_b=2', 'g_c=3', 'aaa=111'}
+    header = cookie_jar.get_header("example.com", "/a/b/c", False)
+    assert set(header.split("; ")) == {"g_a=1", "g_b=2", "g_c=3", "aaa=111"}
 
-    header = cookie_jar.get_header('a.example.com', '/dir_a', False)
-    assert set(header.split('; ')) == {'g_a=1', 'g_b=2', 'g_c=3'}
+    header = cookie_jar.get_header("a.example.com", "/dir_a", False)
+    assert set(header.split("; ")) == {"g_a=1", "g_b=2", "g_c=3"}
 
-    header = cookie_jar.get_header('a.example.com', '/dir_a/c/d/e', False)
-    assert set(header.split('; ')) == {'g_a=1', 'g_b=2', 'g_c=3'}
+    header = cookie_jar.get_header("a.example.com", "/dir_a/c/d/e", False)
+    assert set(header.split("; ")) == {"g_a=1", "g_b=2", "g_c=3"}
 
-    header = cookie_jar.get_header('a.example.com', '/dir_a', True)
-    assert set(header.split('; ')) == {'g_a=1', 'g_b=2', 'g_c=3', 'bbb=222', 'ccc=333'}
+    header = cookie_jar.get_header("a.example.com", "/dir_a", True)
+    assert set(header.split("; ")) == {"g_a=1", "g_b=2", "g_c=3", "bbb=222", "ccc=333"}
 
-    header = cookie_jar.get_header('a.example.com', '/dir_a/c/d/e', True)
-    assert set(header.split('; ')) == {'g_a=1', 'g_b=2', 'g_c=3', 'bbb=222', 'ccc=333'}
+    header = cookie_jar.get_header("a.example.com", "/dir_a/c/d/e", True)
+    assert set(header.split("; ")) == {"g_a=1", "g_b=2", "g_c=3", "bbb=222", "ccc=333"}
 
-    header = cookie_jar.get_header('a.example.com', '/dir_b/dir_c/d/e', True)
-    assert set(header.split('; ')) == {'g_a=1', 'g_b=2', 'g_c=3', 'bbb=222', 'ddd=444'}
+    header = cookie_jar.get_header("a.example.com", "/dir_b/dir_c/d/e", True)
+    assert set(header.split("; ")) == {"g_a=1", "g_b=2", "g_c=3", "bbb=222", "ddd=444"}
 
-    cookie_jar.set(Cookie.create('abc', '123', '.example.com', '/dir_a', max_age=5))
-    header = cookie_jar.get_header('a.example.com', '/dir_a/c/d/e', True)
-    assert set(header.split('; ')) == {'g_a=1', 'g_b=2', 'g_c=3', 'bbb=222', 'ccc=333', 'abc=123'}
+    cookie_jar.set(Cookie.create("abc", "123", ".example.com", "/dir_a", max_age=1))
+    header = cookie_jar.get_header("a.example.com", "/dir_a/c/d/e", True)
+    assert set(header.split("; ")) == {"g_a=1", "g_b=2", "g_c=3", "bbb=222", "ccc=333", "abc=123"}
 
     # Wait for the cookie expired
-    time.sleep(5)
-    header = cookie_jar.get_header('a.example.com', '/dir_a/c/d/e', True)
-    assert set(header.split('; ')) == {'g_a=1', 'g_b=2', 'g_c=3', 'bbb=222', 'ccc=333'}
+    time.sleep(1)
+    header = cookie_jar.get_header("a.example.com", "/dir_a/c/d/e", True)
+    assert set(header.split("; ")) == {"g_a=1", "g_b=2", "g_c=3", "bbb=222", "ccc=333"}
 
     cookie_jar.clear()
-    header = cookie_jar.get_header('a.example.com', '/dir_a/c/d/e', True)
-    assert header == ''
+    header = cookie_jar.get_header("a.example.com", "/dir_a/c/d/e", True)
+    assert header == ""
 
 
 def test_cookie_jar_parse_iter():
     """Test parsing cookies from HTTP Set-Cookie header."""
     for cookie in httplib2.CookieJar.parse_iter(
-            'G=7; HttpOnly; SameSite=Strict; domain=example.com; Path=/login/a; MyAttr=1; MyAttr2'):
+        "G=7; HttpOnly; SameSite=Strict; domain=example.com; Path=/login/a; MyAttr=1; MyAttr2"
+    ):
 
-        assert cookie['name'] == 'G'
-        assert cookie['value'] == '7'
-        assert cookie['domain'] == '.example.com'
-        assert cookie['path'] == '/login/a'
-        assert cookie['HttpOnly'] is True
-        assert cookie['SameSite'] == "Strict"
+        assert cookie["name"] == "G"
+        assert cookie["value"] == "7"
+        assert cookie["domain"] == ".example.com"
+        assert cookie["path"] == "/login/a"
+        assert cookie["HttpOnly"] is True
+        assert cookie["SameSite"] == "Strict"
         # custom cookie attribute in the header
-        assert cookie['MyAttr'] == '1'
-        assert cookie['MyAttr2'] is True
+        assert cookie["MyAttr"] == "1"
+        assert cookie["MyAttr2"] is True
 
-    for cookie in httplib2.CookieJar.parse_iter('A=1,B=2,C=3'):
-        assert cookie['name'] in 'ABC'
+    for cookie in httplib2.CookieJar.parse_iter("A=1,B=2,C=3"):
+        assert cookie["name"] in "ABC"
 
 
 def test_cookie_jar_extract_header():
     """Test extracting cookies from HTTP Set-Cookie header to cookie jar"""
     cj = httplib2.CookieJar()
-    cj.extract_header('www.example.com', '/login.cgi', 'A=1;Max-Age=100')
+    cj.extract_header("www.example.com", "/login.cgi", "A=1;Max-Age=100")
     assert len(cj.get()) == 1
 
-    cj.extract_header('www.example.com', '/login.cgi', 'B=2; Max-Age=100,C=3, D=4')
+    cj.extract_header("www.example.com", "/login.cgi", "B=2; Max-Age=100,C=3, D=4")
     assert len(cj.get()) == 4
 
-    cj.extract_header('www.example.com', '/login.cgi', 'A=1;Max-Age=0')
+    cj.extract_header("www.example.com", "/login.cgi", "A=1;Max-Age=0")
     assert len(cj.get()) == 4
 
-    cj.extract_header('www.example.com', '/login.cgi', 'E=5; Expires=Wed, 21 Oct 2015 07:28:00 GMT;Max-Age=0')
-    assert cj.get('www.example.com', '/', 'E').is_expired()
+    cj.extract_header("www.example.com", "/login.cgi", "E=5; Expires=Wed, 21 Oct 2015 07:28:00 GMT;Max-Age=0")
+    assert cj.get("www.example.com", "/", "E").is_expired()
 
     expires = (datetime.utcnow() + timedelta(seconds=5)).strftime("%a, %d %b %Y %H:%M:%S GMT")
-    cj.extract_header('www.example.com', '/login/login.cgi',
-                      'F=6; Expires={}; Secure; HttpOnly; SameSite=Strict'.format(expires))
-    cookie = cj.get('www.example.com', '/login', 'F')
+    cj.extract_header(
+        "www.example.com", "/login/login.cgi", "F=6; Expires={}; Secure; HttpOnly; SameSite=Strict".format(expires)
+    )
+    cookie = cj.get("www.example.com", "/login", "F")
     assert cookie.secure
-    assert cookie.domain == 'www.example.com'
-    assert cookie.path == '/login/'
+    assert cookie.domain == "www.example.com"
+    assert cookie.path == "/login/"
     assert not cookie.is_expired()
 
-    cj.extract_header('www.example.com', '/login/login.cgi',
-                      'G=7; HttpOnly; SameSite=Strict; domain=example.com; Path=/login/a')
-    cookie = cj.get('.example.com', '/login/a', 'G')
+    cj.extract_header(
+        "www.example.com", "/login/login.cgi", "G=7; HttpOnly; SameSite=Strict; domain=example.com; Path=/login/a"
+    )
+    cookie = cj.get(".example.com", "/login/a", "G")
     assert not cookie.secure
-    assert cookie.domain == '.example.com'
-    assert cookie.path == '/login/a/'
+    assert cookie.domain == ".example.com"
+    assert cookie.path == "/login/a/"
     assert not cookie.is_expired()
 
-    cj.extract_header('www.example.com', '/login.cgi', '')
+    cj.extract_header("www.example.com", "/login.cgi", "")
     assert len(cj.get()) == 7
 
 
@@ -284,10 +291,7 @@ def cookie_http2(cookie_jar):
     http.close()
 
 
-SET_COOKIE_HEADERS = (
-    "A=1; Max-Age=100,B=2, C=3",
-    ("A=1; Max-Age=100", "B=2", "C=3")
-)
+SET_COOKIE_HEADERS = ("A=1; Max-Age=100,B=2, C=3", ("A=1; Max-Age=100", "B=2", "C=3"))
 
 
 @pytest.mark.parametrize("cookie_header", SET_COOKIE_HEADERS, ids=["single", "multiple"])
@@ -295,30 +299,29 @@ def test_response_cookie_attribute(cookie_header):
     """ Test the attribute 'cookies' in Response object."""
     http = httplib2.Http()
 
-    with tests.server_const_http(headers={'set-cookie': cookie_header}) as uri:
+    with tests.server_const_http(headers={"set-cookie": cookie_header}) as uri:
         response, _ = http.request(uri, "GET")
         assert len(response.cookies) == 3
-        assert response.cookies['A'] == '1'
-        assert response.cookies['B'] == '2'
-        assert response.cookies['C'] == '3'
+        assert response.cookies["A"] == "1"
+        assert response.cookies["B"] == "2"
+        assert response.cookies["C"] == "3"
 
 
 def test_onetime_cookie():
     http = httplib2.Http()
-    cookies = {'AAA': '111', 'BBB': '222'}
+    cookies = {"AAA": "111", "BBB": "222"}
     handler = tests.http_reflect_with_cookies()
 
     with tests.server_request(handler) as uri:
-        response, content = http.request(
-            uri, "GET", body="this request have one time cookie", cookies=cookies)
+        response, content = http.request(uri, "GET", body="this request have one time cookie", cookies=cookies)
         assert response.status == 200
-        assert dict([ck.split('=') for ck in content.decode().split('; ')]) == cookies
+        assert dict([ck.split("=") for ck in content.decode().split("; ")]) == cookies
 
 
 @pytest.mark.parametrize("cookie_header", SET_COOKIE_HEADERS, ids=["single", "multiple"])
 def test_cookie_manager_enabled(cookie_header, cookie_http):
     print(cookie_header)
-    handler = tests.http_reflect_with_cookies({'/login': cookie_header})
+    handler = tests.http_reflect_with_cookies({"/login": cookie_header})
 
     with tests.server_request(handler, request_count=2) as uri:
         login_url = urllib.parse.urljoin(uri, "/login")
@@ -331,15 +334,15 @@ def test_cookie_manager_enabled(cookie_header, cookie_http):
         assert response.status == 200
 
         if isinstance(cookie_header, (list, tuple)):
-            cookie_header = ', '.join(cookie_header)
-        set_cookies = {ck['name']: ck['value'] for ck in httplib2.CookieJar.parse_iter(cookie_header)}
-        assert dict([ck.split('=') for ck in content.decode().split('; ')]) == set_cookies
+            cookie_header = ", ".join(cookie_header)
+        set_cookies = {ck["name"]: ck["value"] for ck in httplib2.CookieJar.parse_iter(cookie_header)}
+        assert dict([ck.split("=") for ck in content.decode().split("; ")]) == set_cookies
 
 
 def test_cookie_manager_expire(cookie_http):
     expires = (datetime.utcnow() + timedelta(seconds=10)).strftime("%a, %d %b %Y %H:%M:%S GMT")
-    cookie_header = ('A=1', 'B=2; Max-Age=5', 'C=3; Expires={}'.format(expires))
-    handler = tests.http_reflect_with_cookies({'/login': cookie_header})
+    cookie_header = ("A=1", "B=2; Max-Age=5", "C=3; Expires={}".format(expires))
+    handler = tests.http_reflect_with_cookies({"/login": cookie_header})
 
     with tests.server_request(handler, request_count=4, timeout=20) as uri:
         login_url = urllib.parse.urljoin(uri, "/login")
@@ -353,22 +356,20 @@ def test_cookie_manager_expire(cookie_http):
         time.sleep(5)
         response, content = cookie_http.request(op_url, "POST", body="op reques 2")
         assert response.status == 200
-        set_cookies = {'A': '1', 'C': '3'}
-        assert dict([ck.split('=') for ck in content.decode().split('; ')]) == set_cookies
+        set_cookies = {"A": "1", "C": "3"}
+        assert dict([ck.split("=") for ck in content.decode().split("; ")]) == set_cookies
 
         time.sleep(5)
         response, content = cookie_http.request(op_url, "POST", body="op reques 3")
         assert response.status == 200
-        set_cookies = {'A': '1'}
-        assert dict([ck.split('=') for ck in content.decode().split('; ')]) == set_cookies
+        set_cookies = {"A": "1"}
+        assert dict([ck.split("=") for ck in content.decode().split("; ")]) == set_cookies
 
 
 class HttpConnectionWithDNSResolve(httplib2.HTTPConnectionWithTimeout):
-
     def connect(self):
-        host = 'localhost' if self.host.endswith('.example.com') else self.host
-        self.sock = self._create_connection(
-            (host, self.port), self.timeout, self.source_address)
+        host = "localhost" if self.host.endswith(".example.com") else self.host
+        self.sock = self._create_connection((host, self.port), self.timeout, self.source_address)
         self.sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
 
 
@@ -376,95 +377,102 @@ def test_cookie_manager_match(cookie_http):
     # httplib2 client always initiates new connection for new host name.
     # Close the connection after request so server_socket can accept the next
     # request.
-    headers = {'connection': 'close'}
-    handler = tests.http_reflect_with_cookies({
-        '/login': ('A=1; domain=example.com', 'B=2; Domain=example.com; Max-Age=100', 'C=3'),
-        '/login2': 'D=4; domain=example.com; path=/path_a',
-        '/path_a/path_b/login3': 'E=5; domain=example.com'  # test default path
-    }, response_headers=headers)
+    headers = {"connection": "close"}
+    handler = tests.http_reflect_with_cookies(
+        {
+            "/login": ("A=1; domain=example.com", "B=2; Domain=example.com; Max-Age=100", "C=3"),
+            "/login2": "D=4; domain=example.com; path=/path_a",
+            "/path_a/path_b/login3": "E=5; domain=example.com",  # test default path
+        },
+        response_headers=headers,
+    )
 
     with tests.server_request(handler, request_count=8, timeout=30) as uri:
         login_url = urllib.parse.urljoin(uri, "/login")
         response, content = cookie_http.request(
-            login_url, "POST", body="this is a login request",
-            connection_type=HttpConnectionWithDNSResolve)
+            login_url, "POST", body="this is a login request", connection_type=HttpConnectionWithDNSResolve
+        )
         assert response.status == 200
 
         url_parsed = urllib.parse.urlparse(uri)
-        netloc = 'a.example.com:' + str(url_parsed.port)
-        example_url = urllib.parse.urlunparse((
-            url_parsed.scheme, netloc, url_parsed.path, url_parsed.params, url_parsed.query, url_parsed.fragment
-        ))
+        netloc = "a.example.com:" + str(url_parsed.port)
+        example_url = urllib.parse.urlunparse(
+            (url_parsed.scheme, netloc, url_parsed.path, url_parsed.params, url_parsed.query, url_parsed.fragment)
+        )
         op_url = urllib.parse.urljoin(example_url, "/op")
         response, content = cookie_http.request(
-            op_url, "POST", body="op request 1",
-            connection_type=HttpConnectionWithDNSResolve)
+            op_url, "POST", body="op request 1", connection_type=HttpConnectionWithDNSResolve
+        )
         assert response.status == 200
-        expect_cookies = {'A': '1', 'B': '2'}
-        assert dict([ck.split('=') for ck in content.decode().split('; ')]) == expect_cookies
+        expect_cookies = {"A": "1", "B": "2"}
+        assert dict([ck.split("=") for ck in content.decode().split("; ")]) == expect_cookies
 
         login2_url = urllib.parse.urljoin(uri, "/login2")
         response, content = cookie_http.request(
-            login2_url, "POST", body="this is a login request",
-            connection_type=HttpConnectionWithDNSResolve)
+            login2_url, "POST", body="this is a login request", connection_type=HttpConnectionWithDNSResolve
+        )
         assert response.status == 200
 
         op_url = urllib.parse.urljoin(example_url, "/path_a/op?vvv=yes")
         response, content = cookie_http.request(
-            op_url, "POST", body="op request 2",
-            connection_type=HttpConnectionWithDNSResolve)
+            op_url, "POST", body="op request 2", connection_type=HttpConnectionWithDNSResolve
+        )
         assert response.status == 200
-        expect_cookies = {'A': '1', 'B': '2', 'D': '4'}
-        assert dict([ck.split('=') for ck in content.decode().split('; ')]) == expect_cookies
+        expect_cookies = {"A": "1", "B": "2", "D": "4"}
+        assert dict([ck.split("=") for ck in content.decode().split("; ")]) == expect_cookies
 
         op_url = urllib.parse.urljoin(example_url, "/path_b/op?vvv=yes")
         response, content = cookie_http.request(
-            op_url, "POST", body="op request 3",
-            connection_type=HttpConnectionWithDNSResolve)
+            op_url, "POST", body="op request 3", connection_type=HttpConnectionWithDNSResolve
+        )
         assert response.status == 200
-        expect_cookies = {'A': '1', 'B': '2'}
-        assert dict([ck.split('=') for ck in content.decode().split('; ')]) == expect_cookies
+        expect_cookies = {"A": "1", "B": "2"}
+        assert dict([ck.split("=") for ck in content.decode().split("; ")]) == expect_cookies
 
         login3_url = urllib.parse.urljoin(uri, "/path_a/path_b/login3")
         response, content = cookie_http.request(
-            login3_url, "POST", body="this is a login request",
-            connection_type=HttpConnectionWithDNSResolve)
+            login3_url, "POST", body="this is a login request", connection_type=HttpConnectionWithDNSResolve
+        )
         assert response.status == 200
 
         op_url = urllib.parse.urljoin(example_url, "/path_a/op?vvv=yes")
         response, content = cookie_http.request(
-            op_url, "POST", body="op request 4",
-            connection_type=HttpConnectionWithDNSResolve)
+            op_url, "POST", body="op request 4", connection_type=HttpConnectionWithDNSResolve
+        )
         assert response.status == 200
-        expect_cookies = {'A': '1', 'B': '2', 'D': '4'}
-        assert dict([ck.split('=') for ck in content.decode().split('; ')]) == expect_cookies
+        expect_cookies = {"A": "1", "B": "2", "D": "4"}
+        assert dict([ck.split("=") for ck in content.decode().split("; ")]) == expect_cookies
 
         op_url = urllib.parse.urljoin(example_url, "/path_a/path_b/op")
         response, content = cookie_http.request(
-            op_url, "POST", body="op request 5",
-            connection_type=HttpConnectionWithDNSResolve)
+            op_url, "POST", body="op request 5", connection_type=HttpConnectionWithDNSResolve
+        )
         assert response.status == 200
-        expect_cookies = {'A': '1', 'B': '2', 'D': '4', 'E': '5'}
-        assert dict([ck.split('=') for ck in content.decode().split('; ')]) == expect_cookies
+        expect_cookies = {"A": "1", "B": "2", "D": "4", "E": "5"}
+        assert dict([ck.split("=") for ck in content.decode().split("; ")]) == expect_cookies
 
 
 def test_cookie_manager_with_onetime_cookie(cookie_http2):
-    cookies = {'AAA': '111', 'BBB': '222'}
+    cookies = {"AAA": "111", "BBB": "222"}
     handler = tests.http_reflect_with_cookies()
 
     with tests.server_request(handler) as uri:
         url_parsed = urllib.parse.urlparse(uri)
-        netloc = 'a.example.com:' + str(url_parsed.port)
-        example_url = urllib.parse.urlunparse((
-            url_parsed.scheme, netloc, url_parsed.path, url_parsed.params, url_parsed.query, url_parsed.fragment
-        ))
+        netloc = "a.example.com:" + str(url_parsed.port)
+        example_url = urllib.parse.urlunparse(
+            (url_parsed.scheme, netloc, url_parsed.path, url_parsed.params, url_parsed.query, url_parsed.fragment)
+        )
         url = urllib.parse.urljoin(example_url, "/dir_b/dir_c/op")
         response, content = cookie_http2.request(
-            url, "GET", body="this request include cookies from both one-time cookies and cookie jar",
-            connection_type=HttpConnectionWithDNSResolve, cookies=cookies)
+            url,
+            "GET",
+            body="this request include cookies from both one-time cookies and cookie jar",
+            connection_type=HttpConnectionWithDNSResolve,
+            cookies=cookies,
+        )
         assert response.status == 200
-        expect_cookies = {'g_a': '1', 'g_b': '2', 'g_c': '3', 'AAA': '111', 'BBB': '222', 'ddd': '444'}
-        assert dict([ck.split('=') for ck in content.decode().split('; ')]) == expect_cookies
+        expect_cookies = {"g_a": "1", "g_b": "2", "g_c": "3", "AAA": "111", "BBB": "222", "ddd": "444"}
+        assert dict([ck.split("=") for ck in content.decode().split("; ")]) == expect_cookies
 
 
 @pytest.mark.parametrize("redirect_code", httplib2.REDIRECT_CODES)
@@ -477,13 +485,10 @@ def test_cookie_following_30x_redirect(redirect_code, cookie_http):
     routes = {
         "": tests.http_response_bytes(
             status=status_code,
-            headers={
-                'set-cookie': ('A=1; Max-Age=100', 'B=2'),
-                'location': "/final"
-            },
-            body=b"set-cookie header sent"
+            headers={"set-cookie": ("A=1; Max-Age=100", "B=2"), "location": "/final"},
+            body=b"set-cookie header sent",
         ),
-        "/final": tests.http_reflect_with_cookies()
+        "/final": tests.http_reflect_with_cookies(),
     }
     with tests.server_route(routes, request_count=2) as uri:
         response, content = cookie_http.request(uri, "GET")
@@ -492,5 +497,5 @@ def test_cookie_following_30x_redirect(redirect_code, cookie_http):
     destination = urllib.parse.urljoin(uri, "/final")
     assert response["content-location"] == destination
     assert response.previous.status == redirect_code
-    expect_cookies = {'A': '1', 'B': '2'}
-    assert dict([ck.split('=') for ck in content.decode().split('; ')]) == expect_cookies
+    expect_cookies = {"A": "1", "B": "2"}
+    assert dict([ck.split("=") for ck in content.decode().split("; ")]) == expect_cookies

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -47,7 +47,7 @@ def test_pickle_http():
     assert new_http.certificates.credentials == http.certificates.credentials
     assert new_http.cache.cache == http.cache.cache
     for key in new_http.__dict__:
-        if key not in ("cache", "certificates", "credentials"):
+        if key not in ("cache", "certificates", "credentials", "cookie_jar"):
             assert getattr(new_http, key) == getattr(http, key)
 
 


### PR DESCRIPTION
Track and set the cookie header automatically. 
Cookie session can be enabled by the new parameter `cookie_jar`:  
```
cj = httplib2.CookieJar()
http = httplib2.Http(cookie_jar=cj)
```

For cookie persistence, just providing a filename. All the cookie changes will be updated to file in the disk.
```
cj = httplib2.CookieJar(filename='cookie.txt')
http = httplib2.Http(cookie_jar=cj)
```

A new attribute `cookies` of response object to get parsed cookies:
```
response = http.request(...)
print(response.cookies)
```

To set custom cookies to the `request`, you can add them to `Http.request()` method as a parameter directly, the cookies only serve this request.
```
http = httplib2.Http()
http.request(..., cookies={'AAA': '123'})
```
Or you can add them to the cookie jar, these cookies will be managed by cookie jar in subsequent requests.
```
cj = httplib2.CookieJar()
http = httplib2.Http(cookie_jar=cj)
http.cookie_jar.set('AAA', '123', '.example.com', '/dir_a', max_age=0)
```


Fixes #129
