### PR TITLE
Use mock from the standard library

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,6 @@
 flake8==3.4.1
 future==0.16.0
-mock==2.0.0
+mock==2.0.0;python_version<"3.3"
 pytest-cov==2.5.1
 pytest-forked==0.2
 pytest-randomly==1.2.1

--- a/tests/test_cacerts_from_env.py
+++ b/tests/test_cacerts_from_env.py
@@ -1,6 +1,9 @@
 import os
 import sys
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 import tempfile
 import httplib2

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -5,7 +5,10 @@ from __future__ import print_function
 import email.utils
 import errno
 import httplib2
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import os
 import pytest
 from six.moves import http_client, urllib

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -1,5 +1,8 @@
 import httplib2
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import os
 import pickle
 import pytest

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -9,7 +9,10 @@ from __future__ import division
 from __future__ import print_function
 
 import httplib2
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import os
 import pytest
 import socket


### PR DESCRIPTION
Since Python 3.3, mock is part of unittest in the standard library.

Provide compatibility for older versions, since httplib2 seems to still support Python2.