### PR TITLE
Accept TLS min/max version enums

### DIFF
--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -151,15 +151,21 @@ def _build_ssl_context(
     # source: https://docs.python.org/3/library/ssl.html#ssl.SSLContext.maximum_version
     if maximum_version is not None:
         if hasattr(context, "maximum_version"):
-            context.maximum_version = getattr(ssl.TLSVersion, maximum_version)
+            if isinstance(maximum_version, str):
+                context.maximum_version = getattr(ssl.TLSVersion, maximum_version)
+            else:
+                context.maximum_version = maximum_version
         else:
             raise RuntimeError("setting tls_maximum_version requires Python 3.7 and OpenSSL 1.1 or newer")
     if minimum_version is not None:
         if hasattr(context, "minimum_version"):
-            context.minimum_version = getattr(ssl.TLSVersion, minimum_version)
+            if isinstance(minimum_version, str):
+                context.minimum_version = getattr(ssl.TLSVersion, minimum_version)
+            else:
+                context.maximum_version = minimum_version
         else:
             raise RuntimeError("setting tls_minimum_version requires Python 3.7 and OpenSSL 1.1 or newer")
-
+            
     # check_hostname requires python 3.4+
     # we will perform the equivalent in HTTPSConnectionWithTimeout.connect() by calling ssl.match_hostname
     # if check_hostname is not supported.

--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -152,17 +152,15 @@ def _build_ssl_context(
     if maximum_version is not None:
         if hasattr(context, "maximum_version"):
             if isinstance(maximum_version, str):
-                context.maximum_version = getattr(ssl.TLSVersion, maximum_version)
-            else:
-                context.maximum_version = maximum_version
+                maximum_version = getattr(ssl.TLSVersion, maximum_version)
+            context.maximum_version = maximum_version
         else:
             raise RuntimeError("setting tls_maximum_version requires Python 3.7 and OpenSSL 1.1 or newer")
     if minimum_version is not None:
         if hasattr(context, "minimum_version"):
             if isinstance(minimum_version, str):
-                context.minimum_version = getattr(ssl.TLSVersion, minimum_version)
-            else:
-                context.maximum_version = minimum_version
+                minimum_version = getattr(ssl.TLSVersion, minimum_version)
+            context.maximum_version = minimum_version
         else:
             raise RuntimeError("setting tls_minimum_version requires Python 3.7 and OpenSSL 1.1 or newer")
             

--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -160,7 +160,7 @@ def _build_ssl_context(
         if hasattr(context, "minimum_version"):
             if isinstance(minimum_version, str):
                 minimum_version = getattr(ssl.TLSVersion, minimum_version)
-            context.maximum_version = minimum_version
+            context.minimum_version = minimum_version
         else:
             raise RuntimeError("setting tls_minimum_version requires Python 3.7 and OpenSSL 1.1 or newer")
             

--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -163,7 +163,6 @@ def _build_ssl_context(
             context.minimum_version = minimum_version
         else:
             raise RuntimeError("setting tls_minimum_version requires Python 3.7 and OpenSSL 1.1 or newer")
-            
     # check_hostname requires python 3.4+
     # we will perform the equivalent in HTTPSConnectionWithTimeout.connect() by calling ssl.match_hostname
     # if check_hostname is not supported.

--- a/tests/test_https.py
+++ b/tests/test_https.py
@@ -87,6 +87,7 @@ def test_set_min_tls_version_str():
     except socket.error:
         assert expect_success
 
+
 @pytest.mark.skipif(
     not hasattr(tests.ssl_context(), "minimum_version"),
     reason="ssl doesn't support TLS min/max",
@@ -121,7 +122,7 @@ def test_set_max_tls_version_str():
     except socket.error:
         assert expect_success
 
-        
+
 @pytest.mark.skipif(
     not hasattr(tests.ssl_context(), "maximum_version"),
     reason="ssl doesn't support TLS min/max",

--- a/tests/test_https.py
+++ b/tests/test_https.py
@@ -75,7 +75,7 @@ def test_not_trusted_ca():
     not hasattr(tests.ssl_context(), "minimum_version"),
     reason="ssl doesn't support TLS min/max",
 )
-def test_set_min_tls_version():
+def test_set_min_tls_version_str():
     # Test setting minimum TLS version
     # We expect failure on Python < 3.7 or OpenSSL < 1.1
     expect_success = hasattr(ssl.SSLContext(), 'minimum_version')
@@ -87,18 +87,52 @@ def test_set_min_tls_version():
     except socket.error:
         assert expect_success
 
+@pytest.mark.skipif(
+    not hasattr(tests.ssl_context(), "minimum_version"),
+    reason="ssl doesn't support TLS min/max",
+)
+def test_set_min_tls_version_enum():
+    # Test setting minimum TLS version
+    # We expect failure on Python < 3.7 or OpenSSL < 1.1
+    expect_success = hasattr(ssl.SSLContext(), 'minimum_version')
+    try:
+        http = httplib2.Http(tls_minimum_version=ssl.TLSVersion.TLSv1_2)
+        http.request(tests.DUMMY_HTTPS_URL)
+    except RuntimeError:
+        assert not expect_success
+    except socket.error:
+        assert expect_success
+
 
 @pytest.mark.skipif(
     not hasattr(tests.ssl_context(), "maximum_version"),
     reason="ssl doesn't support TLS min/max",
 )
-def test_set_max_tls_version():
+def test_set_max_tls_version_str():
     # Test setting maximum TLS version
     # We expect RuntimeError on Python < 3.7 or OpenSSL < 1.1
     # We expect socket error otherwise
     expect_success = hasattr(ssl.SSLContext(), 'maximum_version')
     try:
         http = httplib2.Http(tls_maximum_version="TLSv1_2")
+        http.request(tests.DUMMY_HTTPS_URL)
+    except RuntimeError:
+        assert not expect_success
+    except socket.error:
+        assert expect_success
+
+        
+@pytest.mark.skipif(
+    not hasattr(tests.ssl_context(), "maximum_version"),
+    reason="ssl doesn't support TLS min/max",
+)
+def test_set_max_tls_version_enum():
+    # Test setting maximum TLS version
+    # We expect RuntimeError on Python < 3.7 or OpenSSL < 1.1
+    # We expect socket error otherwise
+    expect_success = hasattr(ssl.SSLContext(), 'maximum_version')
+    try:
+        http = httplib2.Http(tls_maximum_version=ssl.TLSVersion.TLSv1_2)
         http.request(tests.DUMMY_HTTPS_URL)
     except RuntimeError:
         assert not expect_success

--- a/tests/test_https.py
+++ b/tests/test_https.py
@@ -71,11 +71,19 @@ def test_not_trusted_ca():
             pass
 
 
+def get_testable_tls_versions():
+    if sys.version_info < (3, 7, 0) \
+            or not hasattr(ssl_context(), "minimum_version") \
+            or not hasattr(ssl_context(), "maximum_version"):
+        return ()
+    return (None, "TLSv1_2", ssl.TLSVersion.TLSv1_2)
+
+    
 @pytest.mark.skipif(
     not hasattr(tests.ssl_context(), "minimum_version"),
     reason="ssl doesn't support TLS min/max",
 )
-@pytest.mark.parametrize("version", (None, ssl.TLSVersion.TLSv1_2, "TLSv1_2"))
+@pytest.mark.parametrize("version", get_testable_tls_versions())
 def test_set_min_tls_version(version):
     # Test setting minimum TLS version
     # We expect failure on Python < 3.7 or OpenSSL < 1.1
@@ -93,7 +101,7 @@ def test_set_min_tls_version(version):
     not hasattr(tests.ssl_context(), "maximum_version"),
     reason="ssl doesn't support TLS min/max",
 )
-@pytest.mark.parametrize("version", (None, ssl.TLSVersion.TLSv1_2, "TLSv1_2"))
+@pytest.mark.parametrize("version", get_testable_tls_versions())
 def test_set_max_tls_version(version):
     # Test setting maximum TLS version
     # We expect RuntimeError on Python < 3.7 or OpenSSL < 1.1

--- a/tests/test_https.py
+++ b/tests/test_https.py
@@ -79,7 +79,7 @@ def get_testable_tls_versions():
         return ()
     return (None, "TLSv1_2", ssl.TLSVersion.TLSv1_2)
 
-    
+
 @pytest.mark.skipif(
     not hasattr(tests.ssl_context(), "minimum_version"),
     reason="ssl doesn't support TLS min/max",

--- a/tests/test_https.py
+++ b/tests/test_https.py
@@ -75,7 +75,8 @@ def test_not_trusted_ca():
     not hasattr(tests.ssl_context(), "minimum_version"),
     reason="ssl doesn't support TLS min/max",
 )
-def test_set_min_tls_version_str():
+@pytest.mark.parametrize("version", (None, ssl.TLSVersion.TLSv1_2, "TLSv1_2"))
+def test_set_min_tls_version(version):
     # Test setting minimum TLS version
     # We expect failure on Python < 3.7 or OpenSSL < 1.1
     expect_success = hasattr(ssl.SSLContext(), 'minimum_version')

--- a/tests/test_https.py
+++ b/tests/test_https.py
@@ -81,24 +81,7 @@ def test_set_min_tls_version(version):
     # We expect failure on Python < 3.7 or OpenSSL < 1.1
     expect_success = hasattr(ssl.SSLContext(), 'minimum_version')
     try:
-        http = httplib2.Http(tls_minimum_version="TLSv1_2")
-        http.request(tests.DUMMY_HTTPS_URL)
-    except RuntimeError:
-        assert not expect_success
-    except socket.error:
-        assert expect_success
-
-
-@pytest.mark.skipif(
-    not hasattr(tests.ssl_context(), "minimum_version"),
-    reason="ssl doesn't support TLS min/max",
-)
-def test_set_min_tls_version_enum():
-    # Test setting minimum TLS version
-    # We expect failure on Python < 3.7 or OpenSSL < 1.1
-    expect_success = hasattr(ssl.SSLContext(), 'minimum_version')
-    try:
-        http = httplib2.Http(tls_minimum_version=ssl.TLSVersion.TLSv1_2)
+        http = httplib2.Http(tls_minimum_version=version)
         http.request(tests.DUMMY_HTTPS_URL)
     except RuntimeError:
         assert not expect_success
@@ -110,31 +93,14 @@ def test_set_min_tls_version_enum():
     not hasattr(tests.ssl_context(), "maximum_version"),
     reason="ssl doesn't support TLS min/max",
 )
-def test_set_max_tls_version_str():
+@pytest.mark.parametrize("version", (None, ssl.TLSVersion.TLSv1_2, "TLSv1_2"))
+def test_set_max_tls_version(version):
     # Test setting maximum TLS version
     # We expect RuntimeError on Python < 3.7 or OpenSSL < 1.1
     # We expect socket error otherwise
     expect_success = hasattr(ssl.SSLContext(), 'maximum_version')
     try:
-        http = httplib2.Http(tls_maximum_version="TLSv1_2")
-        http.request(tests.DUMMY_HTTPS_URL)
-    except RuntimeError:
-        assert not expect_success
-    except socket.error:
-        assert expect_success
-
-
-@pytest.mark.skipif(
-    not hasattr(tests.ssl_context(), "maximum_version"),
-    reason="ssl doesn't support TLS min/max",
-)
-def test_set_max_tls_version_enum():
-    # Test setting maximum TLS version
-    # We expect RuntimeError on Python < 3.7 or OpenSSL < 1.1
-    # We expect socket error otherwise
-    expect_success = hasattr(ssl.SSLContext(), 'maximum_version')
-    try:
-        http = httplib2.Http(tls_maximum_version=ssl.TLSVersion.TLSv1_2)
+        http = httplib2.Http(tls_maximum_version=version)
         http.request(tests.DUMMY_HTTPS_URL)
     except RuntimeError:
         assert not expect_success

--- a/tests/test_https.py
+++ b/tests/test_https.py
@@ -4,6 +4,7 @@ from six.moves import urllib
 import socket
 import ssl
 import tests
+import sys
 
 
 def test_get_via_https():

--- a/tests/test_https.py
+++ b/tests/test_https.py
@@ -74,8 +74,8 @@ def test_not_trusted_ca():
 
 def get_testable_tls_versions():
     if sys.version_info < (3, 7, 0) \
-            or not hasattr(ssl_context(), "minimum_version") \
-            or not hasattr(ssl_context(), "maximum_version"):
+            or not hasattr(tests.ssl_context(), "minimum_version") \
+            or not hasattr(tests.ssl_context(), "maximum_version"):
         return ()
     return (None, "TLSv1_2", ssl.TLSVersion.TLSv1_2)
 


### PR DESCRIPTION
Python 3.7+ define TLS versions as an enum in ssl.TLSVersion. Following principle of least surprise for developers reading up on core SSL library, allow the enum to be passed directly to httplib2 without crashing. Crash is due to getattr requiring that the attribute name be a string, which ssl.TLSVersion does not provide. Continue to accept strings for compatibility with existing code bases.