### PR TITLE
Fixes pytest warning about deprecated use --strict in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ addopts =
   --cov=httplib2
   --noconftest
   --showlocals
-  --strict
+  --strict-markers
   --tb=short
   --timeout=17
   --verbose


### PR DESCRIPTION
Fixes pytest warning reported in #192

../../../../../usr/lib/python3.8/site-packages/_pytest/config/__init__.py:1183
  /usr/lib/python3.8/site-packages/_pytest/config/__init__.py:1183: PytestDeprecationWarning: The --strict option is deprecated, use --strict-markers instead.
    self.issue_config_time_warning(

Based on https://github.com/pytest-dev/pytest/issues/8668

Signed-off-by: Tomasz Kłoczko <kloczek@github.com>