### PR TITLE
Add support for Python 3.8 and 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ python:
   - 3.5
   - 3.6
   - 3.7
+  - 3.8
+  - 3.9
 install: pip install $pip_install_common 'codecov>=2.0.15' -r requirements-test.txt
 script: script/test -sv && codecov
 

--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,7 @@ A comprehensive HTTP client library, ``httplib2`` supports many features left ou
     package_data={"httplib2": ["*.txt"]},
     install_requires=read_requirements("requirements.txt"),
     tests_require=read_requirements("requirements-test.txt"),
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     cmdclass={"test": TestCommand},
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,8 @@ A comprehensive HTTP client library, ``httplib2`` supports many features left ou
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: Software Development :: Libraries",
     ],


### PR DESCRIPTION
Add to CI and declare support in Trove classifiers.

Also add `python_requires` to help pip.

---

Python 2.7 and 3.4-3.5 are all EOL, perhaps now's a good time to drop support for them?

https://endoflife.date/python