### PR TITLE
Use pp.common.downcaseTokens for pyparsing v3

### DIFF
--- a/python3/httplib2/auth.py
+++ b/python3/httplib2/auth.py
@@ -3,6 +3,13 @@ import re
 
 import pyparsing as pp
 
+
+try:  # pyparsing>=3.0.0
+    downcaseTokens = pp.common.downcaseTokens
+except AttributeError:
+    downcaseTokens = pp.downcaseTokens
+
+
 from .error import *
 
 UNQUOTE_PAIRS = re.compile(r"\\(.)")
@@ -17,7 +24,7 @@ token68 = pp.Combine(pp.Word("-._~+/" + pp.nums + pp.alphas) + pp.Optional(pp.Wo
 )
 
 quoted_string = pp.dblQuotedString.copy().setName("quoted-string").setParseAction(unquote)
-auth_param_name = token.copy().setName("auth-param-name").addParseAction(pp.downcaseTokens)
+auth_param_name = token.copy().setName("auth-param-name").addParseAction(downcaseTokens)
 auth_param = auth_param_name + pp.Suppress("=") + (quoted_string | token)
 params = pp.Dict(pp.delimitedList(pp.Group(auth_param)))
 

--- a/python3/httplib2/auth.py
+++ b/python3/httplib2/auth.py
@@ -3,14 +3,13 @@ import re
 
 import pyparsing as pp
 
+from .error import *
+
 
 try:  # pyparsing>=3.0.0
     downcaseTokens = pp.common.downcaseTokens
 except AttributeError:
     downcaseTokens = pp.downcaseTokens
-
-
-from .error import *
 
 UNQUOTE_PAIRS = re.compile(r"\\(.)")
 unquote = lambda s, l, t: UNQUOTE_PAIRS.sub(r"\1", t[0][1:-1])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-pyparsing>=2.4.2,<3 # TODO include v3 after dropping Python2 support
+pyparsing>=2.4.2,<3; python_version<'3.0' # TODO remove after dropping Python2 support
+pyparsing>=2.4.2,<4; python_version>'3.0'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pyparsing>=2.4.2,<3; python_version<'3.0' # TODO remove after dropping Python2 support
-pyparsing>=2.4.2,<4; python_version>'3.0'
+pyparsing>=2.4.2,<4, !=3.0.0, !=3.0.1, !=3.0.2, !=3.0.3; python_version>'3.0'


### PR DESCRIPTION
For #207.

Applies the patch @temoto shared in https://github.com/httplib2/httplib2/issues/207#issuecomment-951833266 and adjusts `requirements.txt` to install a compatible version of `pyparsing` based on the Python version.