### PR TITLE
Fix incorrect pytest.mark.skip usage

### DIFF
--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -237,7 +237,7 @@ def test_get_301():
     assert response2.previous.fromcache
 
 
-@pytest.mark.skip(
+@pytest.mark.skipif(
     not os.environ.get("httplib2_test_still_run_skipped") and os.environ.get("PYTHON_VERSION") in ("2.7", "pypy"),
     reason="FIXME: timeout on CI py27 and pypy, works elsewhere",
 )
@@ -379,7 +379,7 @@ def test_get_302_no_location():
     assert content == b""
 
 
-@pytest.mark.skip(
+@pytest.mark.skipif(
     not os.environ.get("httplib2_test_still_run_skipped") and os.environ.get("PYTHON_VERSION") in ("2.7", "pypy"),
     reason="FIXME: timeout on CI py27 and pypy, works elsewhere",
 )

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -11,6 +11,7 @@ try:
 except ImportError:
     import mock
 import os
+import sys
 import pytest
 from six.moves import http_client, urllib
 import socket
@@ -57,7 +58,7 @@ def test_unknown_server():
 
 
 # @pytest.mark.skipif(
-#     os.environ.get("PYTHON_VERSION") in ("2.7", "pypy"),
+#     not os.environ.get("httplib2_test_still_run_skipped") and sys.version_info.major == 2,
 #     reason="Fails on Travis py27/pypy, works elsewhere. See https://travis-ci.org/httplib2/httplib2/jobs/408769880.",
 # )
 @mock.patch("socket.socket.connect", spec=True)
@@ -70,7 +71,7 @@ def test_connection_refused_raises_exception(mock_socket_connect):
 
 
 # @pytest.mark.skipif(
-#     os.environ.get("PYTHON_VERSION") in ("2.7", "pypy"),
+#     not os.environ.get("httplib2_test_still_run_skipped") and sys.version_info.major == 2,
 #     reason="Fails on Travis py27/pypy, works elsewhere. See https://travis-ci.org/httplib2/httplib2/jobs/408769880.",
 # )
 @mock.patch("socket.socket.connect", spec=True)
@@ -238,7 +239,7 @@ def test_get_301():
 
 
 @pytest.mark.skipif(
-    not os.environ.get("httplib2_test_still_run_skipped") and os.environ.get("PYTHON_VERSION") in ("2.7", "pypy"),
+    not os.environ.get("httplib2_test_still_run_skipped") and sys.version_info.major == 2,
     reason="FIXME: timeout on CI py27 and pypy, works elsewhere",
 )
 def test_head_301():
@@ -380,7 +381,7 @@ def test_get_302_no_location():
 
 
 @pytest.mark.skipif(
-    not os.environ.get("httplib2_test_still_run_skipped") and os.environ.get("PYTHON_VERSION") in ("2.7", "pypy"),
+    not os.environ.get("httplib2_test_still_run_skipped") and sys.version_info.major == 2,
     reason="FIXME: timeout on CI py27 and pypy, works elsewhere",
 )
 def test_303():


### PR DESCRIPTION
This would silently skip the test unconditionally, and is a failure in pytest 7.0.0rc1
