### PR TITLE
Fix parsing http_proxy environment.

### DIFF
--- a/python2/httplib2/__init__.py
+++ b/python2/httplib2/__init__.py
@@ -961,34 +961,14 @@ def proxy_info_from_url(url, method="http", noproxy=None):
     """Construct a ProxyInfo from a URL (such as http_proxy env var)
     """
     url = urlparse.urlparse(url)
-    username = None
-    password = None
-    port = None
-    if "@" in url[1]:
-        ident, host_port = url[1].split("@", 1)
-        if ":" in ident:
-            username, password = ident.split(":", 1)
-        else:
-            password = ident
-    else:
-        host_port = url[1]
-    if ":" in host_port:
-        host, port = host_port.split(":", 1)
-    else:
-        host = host_port
-
-    if port:
-        port = int(port)
-    else:
-        port = dict(https=443, http=80)[method]
 
     proxy_type = 3  # socks.PROXY_TYPE_HTTP
     pi = ProxyInfo(
         proxy_type=proxy_type,
-        proxy_host=host,
-        proxy_port=port,
-        proxy_user=username or None,
-        proxy_pass=password or None,
+        proxy_host=url.hostname,
+        proxy_port=url.port or dict(https=443, http=80)[method],
+        proxy_user=url.username or None,
+        proxy_pass=url.password or None,
         proxy_headers=None,
     )
 

--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -930,34 +930,14 @@ def proxy_info_from_url(url, method="http", noproxy=None):
     """Construct a ProxyInfo from a URL (such as http_proxy env var)
     """
     url = urllib.parse.urlparse(url)
-    username = None
-    password = None
-    port = None
-    if "@" in url[1]:
-        ident, host_port = url[1].split("@", 1)
-        if ":" in ident:
-            username, password = ident.split(":", 1)
-        else:
-            password = ident
-    else:
-        host_port = url[1]
-    if ":" in host_port:
-        host, port = host_port.split(":", 1)
-    else:
-        host = host_port
-
-    if port:
-        port = int(port)
-    else:
-        port = dict(https=443, http=80)[method]
 
     proxy_type = 3  # socks.PROXY_TYPE_HTTP
     pi = ProxyInfo(
         proxy_type=proxy_type,
-        proxy_host=host,
-        proxy_port=port,
-        proxy_user=username or None,
-        proxy_pass=password or None,
+        proxy_host=url.hostname,
+        proxy_port=url.port or dict(https=443, http=80)[method],
+        proxy_user=url.username or None,
+        proxy_pass=url.password or None,
         proxy_headers=None,
     )
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -43,8 +43,15 @@ def test_from_url_no_password():
     pi = httplib2.proxy_info_from_url("http://leila@fro.xy:1032")
     assert pi.proxy_host == "fro.xy"
     assert pi.proxy_port == 1032
+    assert pi.proxy_user == "leila"
+    assert pi.proxy_pass is None
+
+
+def test_from_url_ipv6():
+    pi = httplib2.proxy_info_from_url("http://[::1]:8888")
+    assert pi.proxy_host == "::1"
+    assert pi.proxy_port == 8888
     assert pi.proxy_user is None
-    assert pi.proxy_pass == "leila"
 
 
 def test_from_env(monkeypatch):


### PR DESCRIPTION
Parsing proxy was breaking when proxy URL was set to ipv6 address. There
was also weird handling of proxy without a password. We should rely on
parsing those fields in urllib which is present in all supported
versions.