### PR TITLE
Cache dir creation: use exist_ok=True

### DIFF
--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -767,8 +767,7 @@ class FileCache(object):
     def __init__(self, cache, safe=safename):  # use safe=lambda x: md5.new(x).hexdigest() for the old behavior
         self.cache = cache
         self.safe = safe
-        if not os.path.exists(cache):
-            os.makedirs(self.cache)
+        os.makedirs(self.cache, exist_ok=True)
 
     def get(self, key):
         retval = None


### PR DESCRIPTION
os.makedirs(self.cache) can throw FileExistsError if due to a race condition, the directory is created in between the "exists" check and the "makedirs" call. Using exist_ok=True allows us to avoid throwing.