### PR TITLE
docs: fix simple typo, referrring -> referring

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -188,7 +188,7 @@ def test_get_end2end_headers():
     end2end = httplib2._get_end2end_headers(response)
     assert len(end2end) == 0
 
-    # Degenerate case of connection referrring to a header not passed in
+    # Degenerate case of connection referring to a header not passed in
     response = {"connection": "content-type"}
     end2end = httplib2._get_end2end_headers(response)
     assert len(end2end) == 0


### PR DESCRIPTION
There is a small typo in tests/test_other.py.

Should read `referring` rather than `referrring`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md