### PR TITLE
Recursive _errno_from_exception

### DIFF
--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -183,10 +183,19 @@ def _get_end2end_headers(response):
     return [header for header in list(response.keys()) if header not in hopbyhop]
 
 
+_missing = object()
+
+
 def _errno_from_exception(e):
+    # TODO python 3.11+ cheap try: return e.errno except AttributeError: pass
+    errno = getattr(e, "errno", _missing)
+    if errno is not _missing:
+        return errno
+
     # socket.error and common wrap in .args
-    if hasattr(e, "args") and len(e.args) > 0:
-        return _errno_from_exception(e.args[0])
+    args = getattr(e, "args", None)
+    if args:
+        return _errno_from_exception(args[0])
 
     # pysocks.ProxyError wraps in .socket_err
     # https://github.com/httplib2/httplib2/pull/202

--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -193,10 +193,7 @@ def _errno_from_exception(e):
     if hasattr(e, "socket_err"):
         return _errno_from_exception(e.socket_err)
 
-    if hasattr(e, "errno"):
-        return e.errno
-
-    return None
+    return getattr(e, "errno", None)
 
 
 URI = re.compile(r"^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?")

--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -202,7 +202,7 @@ def _errno_from_exception(e):
     if hasattr(e, "socket_err"):
         return _errno_from_exception(e.socket_err)
 
-    return getattr(e, "errno", None)
+    return None
 
 
 URI = re.compile(r"^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?")

--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -185,14 +185,16 @@ def _get_end2end_headers(response):
 
 def _errno_from_exception(e):
     # socket.error and common wrap in .args
-    if len(e.args) > 0:
-        return e.args[0].errno if isinstance(e.args[0], socket.error) else e.errno
+    if hasattr(e, "args") and len(e.args) > 0:
+        return _errno_from_exception(e.args[0])
 
     # pysocks.ProxyError wraps in .socket_err
     # https://github.com/httplib2/httplib2/pull/202
     if hasattr(e, "socket_err"):
-        e_int = e.socket_err
-        return e_int.args[0].errno if isinstance(e_int.args[0], socket.error) else e_int.errno
+        return _errno_from_exception(e.socket_err)
+
+    if hasattr(e, "errno"):
+        return e.errno
 
     return None
 

--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -199,8 +199,9 @@ def _errno_from_exception(e):
 
     # pysocks.ProxyError wraps in .socket_err
     # https://github.com/httplib2/httplib2/pull/202
-    if hasattr(e, "socket_err"):
-        return _errno_from_exception(e.socket_err)
+    socket_err = getattr(e, "socket_err", None)
+    if socket_err:
+        return _errno_from_exception(socket_err)
 
     return None
 


### PR DESCRIPTION
Similar to https://github.com/httplib2/httplib2/pull/202 but the [socket.error](https://docs.python.org/3/library/socket.html) may also have empty args so check the length again, or revert to the `errno` field.

When I was using a proxy that dropped the connection I got this error message

```
socks.GeneralProxyError: Connection closed unexpectedly

During handling of the above exception, another exception occurred:
...
  File "~/Applications/google-cloud-sdk/platform/gsutil/third_party/httplib2/python3/httplib2/__init__.py", line 195, in _errno_from_exception
    return e_int.args[0].errno if isinstance(e_int.args[0], socket.error) else e_int.errno
IndexError: tuple index out of range
```

[httplib2_IndexError_tuple_index_out_of_range.txt](https://github.com/httplib2/httplib2/files/9456292/httplib2_IndexError_tuple_index_out_of_range.txt)

