### PR TITLE
Bugfix for Content-Encoding: deflate

### DIFF
--- a/python2/httplib2/__init__.py
+++ b/python2/httplib2/__init__.py
@@ -17,7 +17,7 @@ __contributors__ = [
     "Sam Ruby",
     "Louis Nyffenegger",
     "Alex Yu",
-    "Lai Han"
+    "Lai Han",
 ]
 __license__ = "MIT"
 __version__ = "0.20.4"
@@ -471,7 +471,7 @@ def _decompressContent(response, new_content):
                 try:
                     content = zlib.decompress(content, zlib.MAX_WBITS)
                 except (IOError, zlib.error):
-                    content = zlib.decompress(content, -zlib.MAX_WBITS)           
+                    content = zlib.decompress(content, -zlib.MAX_WBITS)
             response["content-length"] = str(len(content))
             # Record the historical presence of the encoding in a way the won't interfere.
             response["-content-encoding"] = response["content-encoding"]

--- a/python2/httplib2/__init__.py
+++ b/python2/httplib2/__init__.py
@@ -17,6 +17,7 @@ __contributors__ = [
     "Sam Ruby",
     "Louis Nyffenegger",
     "Alex Yu",
+    "Lai Han"
 ]
 __license__ = "MIT"
 __version__ = "0.20.4"
@@ -467,7 +468,10 @@ def _decompressContent(response, new_content):
             if encoding == "gzip":
                 content = gzip.GzipFile(fileobj=StringIO.StringIO(new_content)).read()
             if encoding == "deflate":
-                content = zlib.decompress(content, -zlib.MAX_WBITS)
+                try:
+                    content = zlib.decompress(content, zlib.MAX_WBITS)
+                except (IOError, zlib.error):
+                    content = zlib.decompress(content, -zlib.MAX_WBITS)           
             response["content-length"] = str(len(content))
             # Record the historical presence of the encoding in a way the won't interfere.
             response["-content-encoding"] = response["content-encoding"]

--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -380,7 +380,10 @@ def _decompressContent(response, new_content):
             if encoding == "gzip":
                 content = gzip.GzipFile(fileobj=io.BytesIO(new_content)).read()
             if encoding == "deflate":
-                content = zlib.decompress(content, -zlib.MAX_WBITS)
+                try:
+                    content = zlib.decompress(content, zlib.MAX_WBITS)
+                except (IOError, zlib.error):
+                    content = zlib.decompress(content, -zlib.MAX_WBITS)
             response["content-length"] = str(len(content))
             # Record the historical presence of the encoding in a way the won't interfere.
             response["-content-encoding"] = response["content-encoding"]

--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -13,7 +13,7 @@ __contributors__ = [
     "Louis Nyffenegger",
     "Mark Pilgrim",
     "Alex Yu",
-    "Lai Han"
+    "Lai Han",
 ]
 __license__ = "MIT"
 __version__ = "0.20.4"

--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -13,6 +13,7 @@ __contributors__ = [
     "Louis Nyffenegger",
     "Mark Pilgrim",
     "Alex Yu",
+    "Lai Han"
 ]
 __license__ = "MIT"
 __version__ = "0.20.4"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -755,6 +755,15 @@ def deflate_decompress(bs):
     return zlib.decompress(bs, -zlib.MAX_WBITS)
 
 
+def zlib_compress(bs):
+    do = zlib.compressobj(9, zlib.DEFLATED, zlib.MAX_WBITS)
+    return do.compress(bs) + do.flush()
+
+
+def zlib_decompress(bs):
+    return zlib.decompress(bs, zlib.MAX_WBITS)
+
+
 def ssl_context(protocol=None):
     """Workaround for old SSLContext() required protocol argument."""
     if sys.version_info < (3, 5, 3):

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -95,3 +95,19 @@ def test_deflate_malformed_response():
         response, content = http.request(uri, "GET")
         assert response.status == 500
         assert response.reason.startswith("Content purported")
+
+        
+def test_zlib_get():
+    # Test that we support zlib compression
+    http = httplib2.Http()
+    response = tests.http_response_bytes(
+        headers={"content-encoding": "deflate"},
+        body=tests.zlib_compress(b"properly compressed"),
+    )
+    with tests.server_const_bytes(response) as uri:
+        response, content = http.request(uri, "GET")
+        assert response.status == 200
+        assert "content-encoding" not in response
+        assert int(response["content-length"]) == len(b"properly compressed")
+        assert content == b"properly compressed"
+        

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -96,7 +96,7 @@ def test_deflate_malformed_response():
         assert response.status == 500
         assert response.reason.startswith("Content purported")
 
-        
+
 def test_zlib_get():
     # Test that we support zlib compression
     http = httplib2.Http()
@@ -110,4 +110,3 @@ def test_zlib_get():
         assert "content-encoding" not in response
         assert int(response["content-length"]) == len(b"properly compressed")
         assert content == b"properly compressed"
-        


### PR DESCRIPTION
As defined in [HTTP Semantics (RFC 9110)](https://httpwg.org/specs/rfc9110.html#field.content-encoding) and [HTTP/1.1 (RFC 2616)](https://www.w3.org/Protocols/HTTP/1.1/rfc2616.pdf), when the value of Content-Encoding in the response header is deflate, the response content should be in zlib format, i.e., zlib-encapsulated deflate encoded data. There are a few non-standard implementations mentioned in RFC 9110 that use deflate encoded data that is not encapsulated in zlib.

In httplib2, the deflate encoding is handled with the following code.
```
content = zlib.decompress(content, -zlib.MAX_WBITS)
```
According to the explanation of zlib: http://www.zlib.net/manual.html#Advanced, this method can only decode the native deflate encoded data, not the zlib wrapped data, and will raise an exception exit when trying to decode it. Therefore, this function needs to be modified so that it should use zlib to decode by default and then try to use native deflate to decode on exception.

Submitted by: LaiHan of NSFOCUS security team