### PR TITLE
Fix disabling cert validation for PROTOCOL_TLS_CLIENT

### DIFF
--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -152,11 +152,8 @@ def _build_ssl_context(
         raise RuntimeError("httplib2 requires Python 3.2+ for ssl.SSLContext")
 
     context = ssl.SSLContext(DEFAULT_TLS_VERSION)
-    # It is required to disable check_hostname validation before changing verify_mode to CERT_NONE
-    # for PROTOCOL_TLS_CLIENT
-    if DEFAULT_TLS_VERSION.name == 'PROTOCOL_TLS_CLIENT':
-        context.check_hostname = not bool(disable_ssl_certificate_validation)
     context.verify_mode = ssl.CERT_NONE if disable_ssl_certificate_validation else ssl.CERT_REQUIRED
+    context.check_hostname = not disable_ssl_certificate_validation
 
     # SSLContext.maximum_version and SSLContext.minimum_version are python 3.7+.
     # source: https://docs.python.org/3/library/ssl.html#ssl.SSLContext.maximum_version

--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -152,10 +152,7 @@ def _build_ssl_context(
         raise RuntimeError("httplib2 requires Python 3.2+ for ssl.SSLContext")
 
     context = ssl.SSLContext(DEFAULT_TLS_VERSION)
-    # It is required to disable check_hostname validation before changing verify_mode to CERT_NONE
-    # for PROTOCOL_TLS_CLIENT
-    if DEFAULT_TLS_VERSION.name == 'PROTOCOL_TLS_CLIENT':
-        context.check_hostname = not bool(disable_ssl_certificate_validation)
+    context.check_hostname = not disable_ssl_certificate_validation
     context.verify_mode = ssl.CERT_NONE if disable_ssl_certificate_validation else ssl.CERT_REQUIRED
 
     # SSLContext.maximum_version and SSLContext.minimum_version are python 3.7+.

--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -152,7 +152,10 @@ def _build_ssl_context(
         raise RuntimeError("httplib2 requires Python 3.2+ for ssl.SSLContext")
 
     context = ssl.SSLContext(DEFAULT_TLS_VERSION)
-    context.check_hostname = not disable_ssl_certificate_validation
+    # It is required to disable check_hostname validation before changing verify_mode to CERT_NONE
+    # for PROTOCOL_TLS_CLIENT
+    if DEFAULT_TLS_VERSION.name == 'PROTOCOL_TLS_CLIENT':
+        context.check_hostname = not bool(disable_ssl_certificate_validation)
     context.verify_mode = ssl.CERT_NONE if disable_ssl_certificate_validation else ssl.CERT_REQUIRED
 
     # SSLContext.maximum_version and SSLContext.minimum_version are python 3.7+.

--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -152,6 +152,10 @@ def _build_ssl_context(
         raise RuntimeError("httplib2 requires Python 3.2+ for ssl.SSLContext")
 
     context = ssl.SSLContext(DEFAULT_TLS_VERSION)
+    # It is required to disable check_hostname validation before changing verify_mode to CERT_NONE
+    # for PROTOCOL_TLS_CLIENT
+    if DEFAULT_TLS_VERSION.name == 'PROTOCOL_TLS_CLIENT':
+        context.check_hostname = not bool(disable_ssl_certificate_validation)
     context.verify_mode = ssl.CERT_NONE if disable_ssl_certificate_validation else ssl.CERT_REQUIRED
 
     # SSLContext.maximum_version and SSLContext.minimum_version are python 3.7+.

--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -152,8 +152,11 @@ def _build_ssl_context(
         raise RuntimeError("httplib2 requires Python 3.2+ for ssl.SSLContext")
 
     context = ssl.SSLContext(DEFAULT_TLS_VERSION)
+    # check_hostname and verify_mode should be set in opposite order during disable
+    # https://bugs.python.org/issue31431
+    if disable_ssl_certificate_validation and hasattr(context, "check_hostname"):
+        context.check_hostname = not disable_ssl_certificate_validation
     context.verify_mode = ssl.CERT_NONE if disable_ssl_certificate_validation else ssl.CERT_REQUIRED
-    context.check_hostname = not disable_ssl_certificate_validation
 
     # SSLContext.maximum_version and SSLContext.minimum_version are python 3.7+.
     # source: https://docs.python.org/3/library/ssl.html#ssl.SSLContext.maximum_version

--- a/tests/test_https.py
+++ b/tests/test_https.py
@@ -197,3 +197,10 @@ def test_https_redirect_http():
             assert response["content-location"] == uri_http
             assert response.previous.status == 301
             assert response.previous["content-location"] == uri_https
+
+
+def test_disable_ssl_certificate_validation():
+    http = httplib2.Http(disable_ssl_certificate_validation=True)
+    with tests.server_const_http(tls=True) as uri:
+        response, _ = http.request(uri, "GET")
+        assert response.status == 200


### PR DESCRIPTION
I have encountered a problem with making HTTP requests when SSL cert validation is disabled. It is very easy to reproduce

```python
from httplib2 import Http, DEFAULT_TLS_VERSION
Http(disable_ssl_certificate_validation=True).request('https://github.com')
```

It turns out that if DEFAULT_TLS_VERSION is PROTOCOL_TLS_CLIENT then the following error will be thrown:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/tomasz.ziolkowski/venv/vclient-venv/lib/python3.8/site-packages/httplib2/__init__.py", line 1577, in request
    conn = self.connections[conn_key] = connection_type(
  File "/Users/tomasz.ziolkowski/venv/vclient-venv/lib/python3.8/site-packages/httplib2/__init__.py", line 1096, in __init__
    context = _build_ssl_context(
  File "/Users/tomasz.ziolkowski/venv/vclient-venv/lib/python3.8/site-packages/httplib2/__init__.py", line 155, in _build_ssl_context
    context.verify_mode = ssl.CERT_NONE if disable_ssl_certificate_validation else ssl.CERT_REQUIRED
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/ssl.py", line 720, in verify_mode
    super(SSLContext, SSLContext).verify_mode.__set__(self, value)
ValueError: Cannot set verify_mode to CERT_NONE when check_hostname is enabled.
```

After short digging, I found a [change](https://github.com/httplib2/httplib2/commit/992ff25c536f7cc772768c5236ac314e73f45483) that cause a problem.

My proposal is to disable check_hostname before disabling cert validation for PROTOCOL_TLS_CLIENT.

Signed-off-by: tomasz.ziolkowski <tomasz.ziolkowski@allegro.pl>