### PR TITLE
Added code to force authentication on first request instead of authentication-challenge

### DIFF
--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -1088,6 +1088,7 @@ class HTTPSConnectionWithTimeout(http.client.HTTPSConnection):
         tls_maximum_version=None,
         tls_minimum_version=None,
         key_password=None,
+        forceauth=False,
     ):
 
         self.disable_ssl_certificate_validation = disable_ssl_certificate_validation
@@ -1282,6 +1283,9 @@ class Http(object):
         # authorization objects
         self.authorizations = []
 
+        # Whether to use auth on first try
+        self.forceauth = forceauth
+
         # If set to False then no redirects are followed, even safe ones.
         self.follow_redirects = True
 
@@ -1339,6 +1343,13 @@ class Http(object):
             for scheme in AUTH_SCHEME_ORDER:
                 if scheme in challenges:
                     yield AUTH_SCHEME_CLASSES[scheme](cred, host, request_uri, headers, response, content, self)
+
+    def _auth_from_definition(self, host, request_uri, headers, scheme):
+        """A generator that creates an Authorization object
+           based on a scheme specification.
+        """
+        for cred in self.credentials.iter(host):
+            yield AUTH_SCHEME_CLASSES[scheme](cred, host, request_uri, headers, '', '', self)
 
     def add_credentials(self, name, password, domain=""):
         """Add a name and password that will be used
@@ -1435,6 +1446,11 @@ class Http(object):
     ):
         """Do the actual request using the connection object
         and also follow one level of redirects if necessary"""
+
+        if self.forceauth:
+            for authorization in self._auth_from_definition(
+                host, request_uri, headers, self.forceauth):
+                authorization.request(method, request_uri, headers, body)
 
         auths = [(auth.depth(request_uri), auth) for auth in self.authorizations if auth.inscope(host, request_uri)]
         auth = auths and sorted(auths)[0][1] or None


### PR DESCRIPTION
Added "forceauth" parameter to address issue #175. 

Current default behavior is kept:
```
>>> h = httplib2.Http(".cache")
>>> h.add_credentials(user, password)
>>> headersDict={'Content-Type':'application/json','accept':'application/json'}
>>> response, content = h.request(url, 'GET', headers=headersDict)
>>> 
>>> response.status
401
>>> 
```
The webserver in the example above does not return a "www-authenticate" header, and so authentication is not tried (even though credentials are provided and a 401 is received in the first attempt):
```
>>> response
{'date': 'Wed, 31 May 2023 12:29:44 GMT', 'server': 'Apache', 'content-type': 'application/json; charset=utf-8', 'apipie-checksum': '5346b3362dcb7d38bd1dd226bc763427f7fe8200', 'cache-control': 'no-cache', 'x-request-id': 'e27cfd25-00ad-466a-b03f-c1a849001697', 'x-runtime': '0.026089', 'strict-transport-security': 'max-age=631139040; includeSubdomains', 'x-frame-options': 'sameorigin', 'x-content-type-options': 'nosniff', 'x-xss-protection': '1; mode=block', 'x-download-options': 'noopen', 'x-permitted-cross-domain-policies': 'none', 'content-security-policy': "default-src 'self'; child-src 'self'; connect-src 'self' ws: wss:; img-src 'self' data:; script-src 'unsafe-eval' 'unsafe-inline' 'self'; style-src 'unsafe-inline' 'self'", 'via': '1.1 satellite.keller.lab', 'transfer-encoding': 'chunked', 'status': '401'}
```
>>> 
And from the webserver side:
```
192.168.122.149 - - [31/May/2023:12:29:44 +0000] "GET /api/hosts HTTP/1.1" 401 58 "-" "Python-httplib2/0.13.1 (gzip)"
```

Forcing auth allows successful login on the first try:
```
>>> h2 = httplib2.Http(forceauth="basic")
>>> h2.add_credentials(user, password)
>>> response, content = h2.request(url, 'GET', headers=headersDict)
>>> 
>>> response.status
200
>>> 
```
```
192.168.122.149 - - [31/May/2023:12:45:05 +0000] "GET /api/hosts HTTP/1.1" 200 69189 "-" "Python-httplib2/0.13.1 (gzip)"
```
Feedback/corrections are welcome, as this is my first take of an issue here in httplib2.