### PR TITLE
Add support for Python 3.12-3.13

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: cache pip
         uses: actions/cache@v3
@@ -27,7 +27,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: setup python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: 3.x
       - name: install tools
@@ -42,7 +42,7 @@ jobs:
       - name: script/test install_check_version
         run: stages=venv,check_version script/test
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: dist
           path: dist/
@@ -58,7 +58,7 @@ jobs:
 
     steps:
       - name: cache pip
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-publish
@@ -66,13 +66,13 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.x
       - name: install tools
         run: pip install twine
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: dist
           path: dist/
@@ -104,13 +104,13 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: setup python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: 3.x
       - name: install tools
         run: pip install twine
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: dist
           path: dist/

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: cache pip
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-publish
@@ -27,7 +27,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.x
       - name: install tools
@@ -42,7 +42,7 @@ jobs:
       - name: script/test install_check_version
         run: stages=venv,check_version script/test
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist/
@@ -58,7 +58,7 @@ jobs:
 
     steps:
       - name: cache pip
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-publish
@@ -66,13 +66,13 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.x
       - name: install tools
         run: pip install twine
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist/
@@ -96,7 +96,7 @@ jobs:
 
     steps:
       - name: cache pip
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-publish
@@ -104,13 +104,13 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.x
       - name: install tools
         run: pip install twine
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist/

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -10,7 +10,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: setup python
         uses: actions/setup-python@v4

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.x
           cache: pip

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,6 +4,8 @@ on:
   pull_request:
   schedule:
     - cron: "34 4 */7 * *" # every week, time chosen by RNG
+env:
+  FORCE_COLOR: 1
 jobs:
   test:
     name: "test ${{ matrix.py }}"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,6 +27,7 @@ jobs:
           - { py: "3.10", ignore-error: false, os: ubuntu-latest }
           - { py: "3.11", ignore-error: false, os: ubuntu-latest }
           - { py: "3.12", ignore-error: false, os: ubuntu-latest }
+          - { py: "3.13", ignore-error: false, os: ubuntu-latest }
           - { py: 3.x, ignore-error: true, os: ubuntu-latest }
           - { py: pypy2.7, ignore-error: false, os: ubuntu-latest }
           - { py: pypy3.9, ignore-error: false, os: ubuntu-latest }

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,7 +29,7 @@ jobs:
           - { py: pypy3.9, ignore-error: false, os: ubuntu-latest }
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: setup python ${{ matrix.py }}
         uses: actions/setup-python@v4
@@ -56,7 +56,7 @@ jobs:
     if: false && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'httplib2/httplib2')
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: cache pip
         uses: actions/cache@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,6 +24,7 @@ jobs:
           - { py: 3.9, ignore-error: false, os: ubuntu-latest }
           - { py: "3.10", ignore-error: false, os: ubuntu-latest }
           - { py: "3.11", ignore-error: false, os: ubuntu-latest }
+          - { py: "3.12", ignore-error: false, os: ubuntu-latest }
           - { py: 3.x, ignore-error: true, os: ubuntu-latest }
           - { py: pypy2.7, ignore-error: false, os: ubuntu-latest }
           - { py: pypy3.9, ignore-error: false, os: ubuntu-latest }
@@ -35,6 +36,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.py }}
+          allow-prereleases: true
           cache: pip
           cache-dependency-path: |
             pyproject.toml

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: setup python ${{ matrix.py }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.py }}
           allow-prereleases: true
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: cache pip
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache
           key: ${{ runner.os }}-py37_openssl11-${{ hashFiles('.github/workflows/test.yaml', 'pyproject.toml', 'requirements.txt', 'requirements-test.txt', 'setup.py') }}

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,9 +5,9 @@ mock==2.0.0;python_version<"3.3"
 pytest-cov==2.12.1
 pytest-forked==1.3.0
 pytest-randomly==1.2.3
-pytest-timeout==1.4.2
+pytest-timeout==2.1.0
 pytest-xdist==1.34.0
 pytest==4.6.11;python_version<="3.4"
 pytest==6.1.2;python_version>"3.4" and python_version<"3.10"
-pytest==6.2.5;python_version>="3.10"
-six==1.10.0
+pytest==7.4.2;python_version>="3.10"
+six==1.16.0

--- a/setup.py
+++ b/setup.py
@@ -108,6 +108,7 @@ A comprehensive HTTP client library, ``httplib2`` supports many features left ou
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: Software Development :: Libraries",
     ],

--- a/setup.py
+++ b/setup.py
@@ -109,6 +109,7 @@ A comprehensive HTTP client library, ``httplib2`` supports many features left ou
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: Software Development :: Libraries",
     ],


### PR DESCRIPTION
The [second Python 3.12 release candidate](https://discuss.python.org/t/python-3-12-0rc2-final-release-candidate-released/33105/5?u=hugovk) is out! :rocket:

> ## Call to action
> 
> We strongly encourage maintainers of third-party Python projects to prepare their projects for 3.12 compatibilities during this phase, and where necessary publish Python 3.12 wheels on PyPI to be ready for the final release of 3.12.0.

