### PR TITLE
https: avoid costly load_verify_locations when SSL certificate validation is disabled

### DIFF
--- a/httplib2/__init__.py
+++ b/httplib2/__init__.py
@@ -178,7 +178,8 @@ def _build_ssl_context(
     if hasattr(context, "check_hostname"):
         context.check_hostname = not disable_ssl_certificate_validation
 
-    context.load_verify_locations(ca_certs)
+    if not disable_ssl_certificate_validation:
+        context.load_verify_locations(ca_certs)
 
     if cert_file:
         context.load_cert_chain(cert_file, key_file, key_password)


### PR DESCRIPTION
We found a performance regression when validating Splunk against OpenSSL3 - because `load_verify_locations` is incredibly slow there.

There are use cases where we're implicitly trusting the server certificate (e.g. subprocess calling its parent's REST API). Since the server certificate isn't going to be validated, there is no need to load the CA files (let me know if I'm mistaken here!).

I wrote a sample script where httplib2 object is created and makes a GET request to some simple Splunk REST endpoint (500 iterations).

Cert validation disabled, `load_verify_locations` skipped (this PR):
```
host:~/main$ time python https_test.py --skip-validation

real    0m4.153s
user    0m1.107s
sys     0m0.213s
```

Cert validation disabled, `load_verify_locations` not skipped (current `master` branch):
```
host:~/main$ time python https_test.py --skip-validation

real    0m14.599s
user    0m11.336s
sys     0m0.350s
```

Also, attaching py-spy flame graphs that shows the dominant impact of `_build_ssl_context` for the current main branch: ![profile_without_validation_main_branch](https://github.com/user-attachments/assets/78125fc9-a64d-4eac-9071-667ad70ab821), vs this PR: 
![profile_without_validation_fixed](https://github.com/user-attachments/assets/3f4fee0a-849f-4273-904a-2b9724b70a58)


