### PR TITLE
auth: use pyparsing v3 PEP8-compliant method names

### DIFF
--- a/httplib2/auth.py
+++ b/httplib2/auth.py
@@ -5,32 +5,27 @@ import pyparsing as pp
 from .error import MalformedHeader
 
 
-try:  # pyparsing>=3.0.0
-    downcaseTokens = pp.common.downcaseTokens
-except AttributeError:
-    downcaseTokens = pp.downcaseTokens
-
 UNQUOTE_PAIRS = re.compile(r"\\(.)")
 unquote = lambda s, _, t: UNQUOTE_PAIRS.sub(r"\1", t[0][1:-1])
 
 # https://tools.ietf.org/html/rfc7235#section-1.2
 # https://tools.ietf.org/html/rfc7235#appendix-B
 tchar = "!#$%&'*+-.^_`|~" + pp.nums + pp.alphas
-token = pp.Word(tchar).setName("token")
-token68 = pp.Combine(pp.Word("-._~+/" + pp.nums + pp.alphas) + pp.Optional(pp.Word("=").leaveWhitespace())).setName(
+token = pp.Word(tchar).set_name("token")
+token68 = pp.Combine(pp.Word("-._~+/" + pp.nums + pp.alphas) + pp.Optional(pp.Word("=").leave_whitespace())).set_name(
     "token68"
 )
 
-quoted_string = pp.dblQuotedString.copy().setName("quoted-string").setParseAction(unquote)
-auth_param_name = token.copy().setName("auth-param-name").addParseAction(downcaseTokens)
+quoted_string = pp.dbl_quoted_string.copy().set_name("quoted-string").set_parse_action(unquote)
+auth_param_name = token.copy().set_name("auth-param-name").add_parse_action(pp.common.downcase_tokens)
 auth_param = auth_param_name + pp.Suppress("=") + (quoted_string | token)
-params = pp.Dict(pp.delimitedList(pp.Group(auth_param)))
+params = pp.Dict(pp.DelimitedList(pp.Group(auth_param)))
 
 scheme = token("scheme")
 challenge = scheme + (params("params") | token68("token"))
 
 authentication_info = params.copy()
-www_authenticate = pp.delimitedList(pp.Group(challenge))
+www_authenticate = pp.DelimitedList(pp.Group(challenge))
 
 
 def _parse_authentication_info(headers, headername="authentication-info"):
@@ -40,12 +35,12 @@ def _parse_authentication_info(headers, headername="authentication-info"):
     if not header:
         return {}
     try:
-        parsed = authentication_info.parseString(header)
+        parsed = authentication_info.parse_string(header)
     except pp.ParseException:
         # print(ex.explain(ex))
         raise MalformedHeader(headername)
 
-    return parsed.asDict()
+    return parsed.as_dict()
 
 
 def _parse_www_authenticate(headers, headername="www-authenticate"):
@@ -54,13 +49,13 @@ def _parse_www_authenticate(headers, headername="www-authenticate"):
     if not header:
         return {}
     try:
-        parsed = www_authenticate.parseString(header)
+        parsed = www_authenticate.parse_string(header)
     except pp.ParseException:
         # print(ex.explain(ex))
         raise MalformedHeader(headername)
 
     retval = {
-        challenge["scheme"].lower(): challenge["params"].asDict()
+        challenge["scheme"].lower(): challenge["params"].as_dict()
         if "params" in challenge
         else {"token": challenge.get("token")}
         for challenge in parsed


### PR DESCRIPTION
pyparsing 3.3 now emits DeprecationWarning when using the old camel-case methods. cf https://github.com/pyparsing/pyparsing/releases/tag/3.3.0

We also drop the import fallback for downcaseTokens, as httplib2 depends on pyparsing >= 3 since 1a6ff781792099e9e14d7beb610bd99112b17b07